### PR TITLE
ci: add VSDD-aligned issues/pulls/testing workflows

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -60,6 +60,9 @@ runs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ inputs.api-key }}
+        # Default mode is `tag` (only runs on @claude mentions). We want
+        # autonomous one-shot execution per the prompt input.
+        mode: agent
         prompt: |
           ${{ inputs.prompt }}
 

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -1,10 +1,10 @@
 name: "Claude agent"
 description: |
-  Invokes Anthropic's Messages API with a prompt; writes Claude's response
-  text to `output-file` so the caller reads it directly. Centralizes every
-  Claude invocation in this repo so 'where do agents touch the CI?' is a
-  single grep. Uses curl directly rather than anthropics/claude-code-action
-  to avoid bun runtime issues that have been intermittent in agent mode.
+  Invokes the Claude Code CLI (`@anthropic-ai/claude-code`) with a stdin
+  file (and optional inline prompt prepended), leaves stdout in an output
+  file the caller reads directly. Mirrors the gemini composite action's
+  shape so 'where do agents touch the CI?' is a single grep AND so both
+  agents have the same invocation contract.
 
 inputs:
   org:
@@ -12,32 +12,28 @@ inputs:
     required: false
     default: "sw2m"
   prompt:
-    description: "Prompt for Claude. Multi-line OK. Concatenated with stdin-file content (if provided) before sending."
+    description: "Optional inline prompt prepended to stdin-file before piping to claude."
     required: false
     default: ""
   stdin-file:
-    description: "Path to a file whose content is appended to the prompt before sending. Required because Claude has no filesystem access via the Messages API — any 'read this file' instruction must instead embed the file's content here."
+    description: "Path to a file whose contents are appended to `prompt` and piped as stdin to claude. Preferred over `prompt` for content larger than a few KB."
     required: false
     default: ""
+  model:
+    description: "Claude model id."
+    required: false
+    default: "claude-opus-4-5"
   api-key:
     description: "ANTHROPIC_API_KEY value (caller passes via secret)."
     required: true
-  model:
-    description: "Anthropic model id."
-    required: false
-    default: "claude-opus-4-5"
-  max-tokens:
-    description: "Max tokens for the response."
-    required: false
-    default: "8192"
   output-file:
-    description: "File path Claude's response text is written to. Caller reads from this path."
+    description: "Where claude's stdout is written. Caller reads from this path after the action runs."
     required: false
     default: "claude-output.txt"
 
 outputs:
   output-file:
-    description: "Path to the file Claude wrote (echoes back the input)."
+    description: "Path to the file containing claude stdout (echoes back the input)."
     value: ${{ inputs.output-file }}
 
 runs:
@@ -65,107 +61,59 @@ runs:
         fi
         echo "✓ $ACTOR is a $ORG org member (public)."
 
-    - name: Build full prompt (prompt + stdin-file content)
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install Claude Code CLI
+      shell: bash
+      run: npm install -g @anthropic-ai/claude-code@latest
+
+    - name: Invoke claude (--print, no tools)
       shell: bash
       env:
+        ANTHROPIC_API_KEY: ${{ inputs.api-key }}
         PROMPT: ${{ inputs.prompt }}
         STDIN_FILE: ${{ inputs.stdin-file }}
+        MODEL: ${{ inputs.model }}
+        OUTPUT: ${{ inputs.output-file }}
       run: |
         set -euo pipefail
-        : > combined-prompt.txt
+        : > combined-input.txt
         if [ -n "$PROMPT" ]; then
-          printf '%s\n\n' "$PROMPT" >> combined-prompt.txt
+          printf '%s\n\n' "$PROMPT" >> combined-input.txt
         fi
         if [ -n "$STDIN_FILE" ]; then
           if [ ! -f "$STDIN_FILE" ]; then
             echo "::error::stdin-file '$STDIN_FILE' does not exist."
             exit 1
           fi
-          cat "$STDIN_FILE" >> combined-prompt.txt
+          cat "$STDIN_FILE" >> combined-input.txt
         fi
-        if [ ! -s combined-prompt.txt ]; then
-          echo "::error::No content to send to Claude (both prompt and stdin-file were empty)."
+        if [ ! -s combined-input.txt ]; then
+          echo "::error::No content to send to claude (both prompt and stdin-file were empty)."
           exit 1
         fi
-        echo "prompt bytes: $(wc -c < combined-prompt.txt)"
+        echo "input bytes: $(wc -c < combined-input.txt)"
 
-    - name: Call Anthropic Messages API
-      shell: bash
-      env:
-        ANTHROPIC_API_KEY: ${{ inputs.api-key }}
-        MODEL: ${{ inputs.model }}
-        MAX_TOKENS: ${{ inputs.max-tokens }}
-        OUTPUT: ${{ inputs.output-file }}
-      run: |
-        set -euo pipefail
-        # Build the JSON request safely with python so the prompt content
-        # (including the embedded file body) round-trips correctly through
-        # JSON encoding even with quotes / newlines / backslashes.
-        python3 - <<'PY' > request.json
-        import json, os
-        prompt = open('combined-prompt.txt').read()
-        body = {
-            "model": os.environ["MODEL"],
-            "max_tokens": int(os.environ["MAX_TOKENS"]),
-            "messages": [
-                {"role": "user", "content": prompt}
-            ],
-        }
-        print(json.dumps(body))
-        PY
-
-        echo "request bytes: $(wc -c < request.json)"
-
-        # Call the API. Capture the body and the HTTP status separately.
-        http_code=$(curl -sS \
-          -o response.json -w "%{http_code}" \
-          -H "x-api-key: $ANTHROPIC_API_KEY" \
-          -H "anthropic-version: 2023-06-01" \
-          -H "content-type: application/json" \
-          -X POST \
-          --data @request.json \
-          https://api.anthropic.com/v1/messages)
-
-        echo "HTTP $http_code"
-
-        if [ "$http_code" != "200" ]; then
-          echo "::error::Anthropic Messages API returned HTTP $http_code."
-          echo "--- response body ---"
-          cat response.json
-          exit 1
-        fi
-
-        # Extract the text from response.content[0].text. The API returns a
-        # list of content blocks; for a plain prompt we expect exactly one
-        # text block.
-        python3 - <<'PY'
-        import json, sys
-        r = json.load(open('response.json'))
-        blocks = r.get('content', [])
-        if not blocks:
-            print('ERROR: response had no content blocks', file=sys.stderr)
-            json.dump(r, sys.stderr, indent=2)
-            sys.exit(1)
-        # Concatenate text from every text-typed block.
-        text = "".join(b.get('text', '') for b in blocks if b.get('type') == 'text')
-        if not text.strip():
-            print('ERROR: response had no text content', file=sys.stderr)
-            json.dump(r, sys.stderr, indent=2)
-            sys.exit(1)
-        with open(__import__('os').environ['OUTPUT'], 'w') as f:
-            f.write(text)
-        print(f"wrote {len(text)} chars to {__import__('os').environ['OUTPUT']}")
-        print("first 500 chars:")
-        print(text[:500])
-        PY
+        # `--print` = non-interactive single-turn; pipe stdin as the prompt.
+        # We deliberately do NOT enable tools — this is pure inference. The
+        # CLI's default permission gate would prompt for tool use anyway
+        # in a non-TTY context, but being explicit here is cheap insurance.
+        claude --print --model "$MODEL" --permission-mode plan < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
+        echo "stdout (first 500 chars):"
+        head -c 500 "$OUTPUT"
+        echo ""
+        echo "stderr (last 20 lines):"
+        tail -20 claude-stderr.log || true
 
     - name: Verify output produced
       shell: bash
       env:
         OUTPUT: ${{ inputs.output-file }}
       run: |
-        if [ ! -f "$OUTPUT" ]; then
-          echo "::error::$OUTPUT was not produced."
+        if [ ! -s "$OUTPUT" ]; then
+          echo "::error::$OUTPUT is empty or missing."
           exit 1
         fi
         echo "✓ $OUTPUT exists ($(wc -c < "$OUTPUT") bytes)"

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -97,10 +97,12 @@ runs:
         echo "input bytes: $(wc -c < combined-input.txt)"
 
         # `--print` = non-interactive single-turn; pipe stdin as the prompt.
-        # We deliberately do NOT enable tools — this is pure inference. The
-        # CLI's default permission gate would prompt for tool use anyway
-        # in a non-TTY context, but being explicit here is cheap insurance.
-        claude --print --model "$MODEL" --permission-mode plan < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
+        # Pure inference: we want claude to produce text, not run tools.
+        # `--allowed-tools ""` disables every tool (Bash, Edit, etc.). We
+        # tried `--permission-mode plan` first but plan mode makes claude
+        # write a *plan summary* of what it would do, not actually do it
+        # — useless for our 'produce frontmatter + bullets' contract.
+        claude --print --model "$MODEL" --allowed-tools "" < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
         echo "stdout (first 500 chars):"
         head -c 500 "$OUTPUT"
         echo ""

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -12,8 +12,13 @@ inputs:
     required: false
     default: "sw2m"
   prompt:
-    description: "Prompt for Claude. Multi-line OK."
-    required: true
+    description: "Prompt for Claude. Multi-line OK. Concatenated with stdin-file content (if provided) before sending."
+    required: false
+    default: ""
+  stdin-file:
+    description: "Path to a file whose content is appended to the prompt before sending. Required because Claude has no filesystem access via the Messages API — any 'read this file' instruction must instead embed the file's content here."
+    required: false
+    default: ""
   api-key:
     description: "ANTHROPIC_API_KEY value (caller passes via secret)."
     required: true
@@ -60,25 +65,50 @@ runs:
         fi
         echo "✓ $ACTOR is a $ORG org member (public)."
 
+    - name: Build full prompt (prompt + stdin-file content)
+      shell: bash
+      env:
+        PROMPT: ${{ inputs.prompt }}
+        STDIN_FILE: ${{ inputs.stdin-file }}
+      run: |
+        set -euo pipefail
+        : > combined-prompt.txt
+        if [ -n "$PROMPT" ]; then
+          printf '%s\n\n' "$PROMPT" >> combined-prompt.txt
+        fi
+        if [ -n "$STDIN_FILE" ]; then
+          if [ ! -f "$STDIN_FILE" ]; then
+            echo "::error::stdin-file '$STDIN_FILE' does not exist."
+            exit 1
+          fi
+          cat "$STDIN_FILE" >> combined-prompt.txt
+        fi
+        if [ ! -s combined-prompt.txt ]; then
+          echo "::error::No content to send to Claude (both prompt and stdin-file were empty)."
+          exit 1
+        fi
+        echo "prompt bytes: $(wc -c < combined-prompt.txt)"
+
     - name: Call Anthropic Messages API
       shell: bash
       env:
         ANTHROPIC_API_KEY: ${{ inputs.api-key }}
-        PROMPT: ${{ inputs.prompt }}
         MODEL: ${{ inputs.model }}
         MAX_TOKENS: ${{ inputs.max-tokens }}
         OUTPUT: ${{ inputs.output-file }}
       run: |
         set -euo pipefail
-        # Build the JSON request safely with python so prompt content with
-        # quotes / newlines / backslashes round-trips correctly.
+        # Build the JSON request safely with python so the prompt content
+        # (including the embedded file body) round-trips correctly through
+        # JSON encoding even with quotes / newlines / backslashes.
         python3 - <<'PY' > request.json
         import json, os
+        prompt = open('combined-prompt.txt').read()
         body = {
             "model": os.environ["MODEL"],
             "max_tokens": int(os.environ["MAX_TOKENS"]),
             "messages": [
-                {"role": "user", "content": os.environ["PROMPT"]}
+                {"role": "user", "content": prompt}
             ],
         }
         print(json.dumps(body))

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -1,0 +1,71 @@
+name: "Claude agent"
+description: |
+  Invokes anthropics/claude-code-action with a prompt; instructs Claude to
+  write its result to a file the caller reads directly. Centralizes every
+  Claude invocation in this repo so 'where do agents touch the CI?' is a
+  single grep.
+
+inputs:
+  org:
+    description: "GitHub org whose members are allowed to invoke this agent. Non-members trigger a hard fail. Default sw2m."
+    required: false
+    default: "sw2m"
+  prompt:
+    description: "Prompt for Claude. Multi-line OK. The action automatically appends a 'write to <output-file>' instruction."
+    required: true
+  api-key:
+    description: "ANTHROPIC_API_KEY value (caller passes via secret)."
+    required: true
+  output-file:
+    description: "File Claude is asked to write its result to. Caller reads from this path."
+    required: false
+    default: "claude-output.txt"
+
+outputs:
+  output-file:
+    description: "Path to the file Claude wrote (echoes back the input)."
+    value: ${{ inputs.output-file }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify org membership
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        ACTOR: ${{ github.event.sender.login || github.actor }}
+        ORG: ${{ inputs.org }}
+      run: |
+        # Hard gate: agents must not be invocable by non-org-members.
+        # This lives inside the composite action so consumers cannot forget it.
+        if ! gh api "orgs/$ORG/members/$ACTOR" >/dev/null 2>&1; then
+          echo "::error::$ACTOR is not a member of the '$ORG' GitHub org."
+          echo "Agent invocations (Claude) are restricted to org members. The"
+          echo "calling workflow either ran without the org/repo fork-PR"
+          echo "contributor-approval setting, or the gate is misconfigured."
+          exit 1
+        fi
+        echo "✓ $ACTOR is a $ORG org member."
+
+    - name: Invoke Claude
+      uses: anthropics/claude-code-action@v1
+      with:
+        anthropic_api_key: ${{ inputs.api-key }}
+        prompt: |
+          ${{ inputs.prompt }}
+
+          Write your final result to a file named `${{ inputs.output-file }}` in the working directory. Do NOT commit, push, or open PRs — the calling workflow reads the file directly.
+
+    - name: Verify output produced
+      shell: bash
+      env:
+        OUTPUT: ${{ inputs.output-file }}
+      run: |
+        if [ ! -f "$OUTPUT" ]; then
+          echo "::error::Claude did not produce $OUTPUT."
+          ls -la
+          exit 1
+        fi
+        echo "claude output (first 500 chars):"
+        head -c 500 "$OUTPUT"
+        echo ""

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -61,7 +61,7 @@ runs:
         fi
         echo "✓ $ACTOR is a $ORG org member (public)."
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: "20"
 

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -1,9 +1,10 @@
 name: "Claude agent"
 description: |
-  Invokes anthropics/claude-code-action with a prompt; instructs Claude to
-  write its result to a file the caller reads directly. Centralizes every
+  Invokes Anthropic's Messages API with a prompt; writes Claude's response
+  text to `output-file` so the caller reads it directly. Centralizes every
   Claude invocation in this repo so 'where do agents touch the CI?' is a
-  single grep.
+  single grep. Uses curl directly rather than anthropics/claude-code-action
+  to avoid bun runtime issues that have been intermittent in agent mode.
 
 inputs:
   org:
@@ -11,13 +12,21 @@ inputs:
     required: false
     default: "sw2m"
   prompt:
-    description: "Prompt for Claude. Multi-line OK. The action automatically appends a 'write to <output-file>' instruction."
+    description: "Prompt for Claude. Multi-line OK."
     required: true
   api-key:
     description: "ANTHROPIC_API_KEY value (caller passes via secret)."
     required: true
+  model:
+    description: "Anthropic model id."
+    required: false
+    default: "claude-opus-4-5"
+  max-tokens:
+    description: "Max tokens for the response."
+    required: false
+    default: "8192"
   output-file:
-    description: "File Claude is asked to write its result to. Caller reads from this path."
+    description: "File path Claude's response text is written to. Caller reads from this path."
     required: false
     default: "claude-output.txt"
 
@@ -38,35 +47,87 @@ runs:
       run: |
         # Hard gate: agents must not be invocable by non-org-members.
         # NOTE: the default GITHUB_TOKEN can only see PUBLIC org memberships.
-        # Members whose membership is private are invisible to this check
-        # and will trigger a hard fail. Make membership public on the org
-        # page (Settings → People → "Make public") to be recognized.
         if ! gh api "orgs/$ORG/members/$ACTOR" >/dev/null 2>&1; then
           echo "::error::$ACTOR is not a (publicly-visible) member of the '$ORG' GitHub org."
           echo ""
           echo "If you ARE a member but private: visit"
           echo "https://github.com/orgs/$ORG/people and click 'Make public'"
-          echo "next to your row. The default workflow GITHUB_TOKEN cannot"
-          echo "see private memberships."
+          echo "next to your row."
           echo ""
           echo "If you are not a member: agent invocations (Claude) are"
-          echo "restricted to org members. An org member must open the PR"
-          echo "on your behalf."
+          echo "restricted to org members."
           exit 1
         fi
         echo "✓ $ACTOR is a $ORG org member (public)."
 
-    - name: Invoke Claude
-      uses: anthropics/claude-code-action@v1
-      with:
-        anthropic_api_key: ${{ inputs.api-key }}
-        # Default mode is `tag` (only runs on @claude mentions). We want
-        # autonomous one-shot execution per the prompt input.
-        mode: agent
-        prompt: |
-          ${{ inputs.prompt }}
+    - name: Call Anthropic Messages API
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.api-key }}
+        PROMPT: ${{ inputs.prompt }}
+        MODEL: ${{ inputs.model }}
+        MAX_TOKENS: ${{ inputs.max-tokens }}
+        OUTPUT: ${{ inputs.output-file }}
+      run: |
+        set -euo pipefail
+        # Build the JSON request safely with python so prompt content with
+        # quotes / newlines / backslashes round-trips correctly.
+        python3 - <<'PY' > request.json
+        import json, os
+        body = {
+            "model": os.environ["MODEL"],
+            "max_tokens": int(os.environ["MAX_TOKENS"]),
+            "messages": [
+                {"role": "user", "content": os.environ["PROMPT"]}
+            ],
+        }
+        print(json.dumps(body))
+        PY
 
-          Write your final result to a file named `${{ inputs.output-file }}` in the working directory. Do NOT commit, push, or open PRs — the calling workflow reads the file directly.
+        echo "request bytes: $(wc -c < request.json)"
+
+        # Call the API. Capture the body and the HTTP status separately.
+        http_code=$(curl -sS \
+          -o response.json -w "%{http_code}" \
+          -H "x-api-key: $ANTHROPIC_API_KEY" \
+          -H "anthropic-version: 2023-06-01" \
+          -H "content-type: application/json" \
+          -X POST \
+          --data @request.json \
+          https://api.anthropic.com/v1/messages)
+
+        echo "HTTP $http_code"
+
+        if [ "$http_code" != "200" ]; then
+          echo "::error::Anthropic Messages API returned HTTP $http_code."
+          echo "--- response body ---"
+          cat response.json
+          exit 1
+        fi
+
+        # Extract the text from response.content[0].text. The API returns a
+        # list of content blocks; for a plain prompt we expect exactly one
+        # text block.
+        python3 - <<'PY'
+        import json, sys
+        r = json.load(open('response.json'))
+        blocks = r.get('content', [])
+        if not blocks:
+            print('ERROR: response had no content blocks', file=sys.stderr)
+            json.dump(r, sys.stderr, indent=2)
+            sys.exit(1)
+        # Concatenate text from every text-typed block.
+        text = "".join(b.get('text', '') for b in blocks if b.get('type') == 'text')
+        if not text.strip():
+            print('ERROR: response had no text content', file=sys.stderr)
+            json.dump(r, sys.stderr, indent=2)
+            sys.exit(1)
+        with open(__import__('os').environ['OUTPUT'], 'w') as f:
+            f.write(text)
+        print(f"wrote {len(text)} chars to {__import__('os').environ['OUTPUT']}")
+        print("first 500 chars:")
+        print(text[:500])
+        PY
 
     - name: Verify output produced
       shell: bash
@@ -74,10 +135,7 @@ runs:
         OUTPUT: ${{ inputs.output-file }}
       run: |
         if [ ! -f "$OUTPUT" ]; then
-          echo "::error::Claude did not produce $OUTPUT."
-          ls -la
+          echo "::error::$OUTPUT was not produced."
           exit 1
         fi
-        echo "claude output (first 500 chars):"
-        head -c 500 "$OUTPUT"
-        echo ""
+        echo "✓ $OUTPUT exists ($(wc -c < "$OUTPUT") bytes)"

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -20,9 +20,13 @@ inputs:
     required: false
     default: ""
   model:
-    description: "Claude model id."
+    description: "Primary Claude model id."
     required: false
     default: "claude-opus-4-5"
+  fallback-model:
+    description: "Model to retry with if primary errors (capacity, transient API failure, etc.)."
+    required: false
+    default: "claude-sonnet-4-5"
   api-key:
     description: "ANTHROPIC_API_KEY value (caller passes via secret)."
     required: true
@@ -69,13 +73,14 @@ runs:
       shell: bash
       run: npm install -g @anthropic-ai/claude-code@latest
 
-    - name: Invoke claude (--print, no tools)
+    - name: Invoke claude (--print, no tools, with fallback)
       shell: bash
       env:
         ANTHROPIC_API_KEY: ${{ inputs.api-key }}
         PROMPT: ${{ inputs.prompt }}
         STDIN_FILE: ${{ inputs.stdin-file }}
         MODEL: ${{ inputs.model }}
+        FALLBACK: ${{ inputs.fallback-model }}
         OUTPUT: ${{ inputs.output-file }}
       run: |
         set -euo pipefail
@@ -97,12 +102,29 @@ runs:
         echo "input bytes: $(wc -c < combined-input.txt)"
 
         # `--print` = non-interactive single-turn; pipe stdin as the prompt.
-        # Pure inference: we want claude to produce text, not run tools.
-        # `--allowed-tools ""` disables every tool (Bash, Edit, etc.). We
-        # tried `--permission-mode plan` first but plan mode makes claude
-        # write a *plan summary* of what it would do, not actually do it
-        # — useless for our 'produce frontmatter + bullets' contract.
+        # `--allowed-tools ""` disables every tool. Pure inference; we want
+        # claude to produce text, not run tools. `--permission-mode plan`
+        # was rejected earlier — plan mode produces a "what I would do"
+        # summary instead of doing it.
+        set +e
         claude --print --model "$MODEL" --allowed-tools "" < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
+        rc=$?
+        if [ $rc -ne 0 ]; then
+          echo "::warning::Primary model '$MODEL' exited $rc; falling back to '$FALLBACK'."
+          echo "--- primary stderr ---"
+          cat claude-stderr.log
+          claude --print --model "$FALLBACK" --allowed-tools "" < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "::error::Fallback model '$FALLBACK' also exited $rc."
+            echo "--- fallback stderr ---"
+            cat claude-stderr.log
+            echo "--- fallback stdout ---"
+            cat "$OUTPUT"
+            exit $rc
+          fi
+        fi
+        set -e
         echo "stdout (first 500 chars):"
         head -c 500 "$OUTPUT"
         echo ""

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -37,15 +37,24 @@ runs:
         ORG: ${{ inputs.org }}
       run: |
         # Hard gate: agents must not be invocable by non-org-members.
-        # This lives inside the composite action so consumers cannot forget it.
+        # NOTE: the default GITHUB_TOKEN can only see PUBLIC org memberships.
+        # Members whose membership is private are invisible to this check
+        # and will trigger a hard fail. Make membership public on the org
+        # page (Settings → People → "Make public") to be recognized.
         if ! gh api "orgs/$ORG/members/$ACTOR" >/dev/null 2>&1; then
-          echo "::error::$ACTOR is not a member of the '$ORG' GitHub org."
-          echo "Agent invocations (Claude) are restricted to org members. The"
-          echo "calling workflow either ran without the org/repo fork-PR"
-          echo "contributor-approval setting, or the gate is misconfigured."
+          echo "::error::$ACTOR is not a (publicly-visible) member of the '$ORG' GitHub org."
+          echo ""
+          echo "If you ARE a member but private: visit"
+          echo "https://github.com/orgs/$ORG/people and click 'Make public'"
+          echo "next to your row. The default workflow GITHUB_TOKEN cannot"
+          echo "see private memberships."
+          echo ""
+          echo "If you are not a member: agent invocations (Claude) are"
+          echo "restricted to org members. An org member must open the PR"
+          echo "on your behalf."
           exit 1
         fi
-        echo "✓ $ACTOR is a $ORG org member."
+        echo "✓ $ACTOR is a $ORG org member (public)."
 
     - name: Invoke Claude
       uses: anthropics/claude-code-action@v1

--- a/.github/actions/gemini/action.yml
+++ b/.github/actions/gemini/action.yml
@@ -1,0 +1,121 @@
+name: "Gemini agent"
+description: |
+  Invokes gemini-cli with a stdin file (and optional inline prompt prepended),
+  retries on failure with a fallback model, and leaves stdout in an output
+  file the caller reads directly. Centralizes every gemini invocation in this
+  repo so 'where do agents touch the CI?' is a single grep.
+
+inputs:
+  org:
+    description: "GitHub org whose members are allowed to invoke this agent. Non-members trigger a hard fail. Default sw2m."
+    required: false
+    default: "sw2m"
+  prompt:
+    description: "Optional inline prompt prepended to stdin-file before piping to gemini."
+    required: false
+    default: ""
+  stdin-file:
+    description: "Path to a file whose contents are piped as stdin to gemini after `prompt`. Preferred over `prompt` for content larger than a few KB."
+    required: false
+    default: ""
+  model:
+    description: "Primary gemini model."
+    required: false
+    default: "gemini-3-pro-preview"
+  fallback-model:
+    description: "Model to retry with if primary errors."
+    required: false
+    default: "gemini-2.5-pro"
+  api-key:
+    description: "GEMINI_API_KEY value (caller passes via secret)."
+    required: true
+  output-file:
+    description: "Where gemini stdout is written. Caller reads from this path after the action runs."
+    required: false
+    default: "gemini-output.txt"
+
+outputs:
+  output-file:
+    description: "Path to the file containing gemini stdout (echoes back the input for chaining)."
+    value: ${{ inputs.output-file }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify org membership
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        ACTOR: ${{ github.event.sender.login || github.actor }}
+        ORG: ${{ inputs.org }}
+      run: |
+        # Hard gate: agents must not be invocable by non-org-members.
+        # This lives inside the composite action so consumers cannot forget it.
+        if ! gh api "orgs/$ORG/members/$ACTOR" >/dev/null 2>&1; then
+          echo "::error::$ACTOR is not a member of the '$ORG' GitHub org."
+          echo "Agent invocations (Gemini) are restricted to org members. The"
+          echo "calling workflow either ran without the org/repo fork-PR"
+          echo "contributor-approval setting, or the gate is misconfigured."
+          exit 1
+        fi
+        echo "✓ $ACTOR is a $ORG org member."
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install gemini-cli
+      shell: bash
+      run: npm install -g @google/gemini-cli@latest
+
+    - name: Invoke gemini (primary, then fallback on error)
+      shell: bash
+      env:
+        GEMINI_API_KEY: ${{ inputs.api-key }}
+        PROMPT: ${{ inputs.prompt }}
+        STDIN_FILE: ${{ inputs.stdin-file }}
+        MODEL: ${{ inputs.model }}
+        FALLBACK: ${{ inputs.fallback-model }}
+        OUTPUT: ${{ inputs.output-file }}
+      run: |
+        set -euo pipefail
+        : > combined-input.txt
+        if [ -n "$PROMPT" ]; then
+          printf '%s\n\n' "$PROMPT" >> combined-input.txt
+        fi
+        if [ -n "$STDIN_FILE" ]; then
+          if [ ! -f "$STDIN_FILE" ]; then
+            echo "::error::stdin-file '$STDIN_FILE' does not exist."
+            exit 1
+          fi
+          cat "$STDIN_FILE" >> combined-input.txt
+        fi
+        if [ ! -s combined-input.txt ]; then
+          echo "::error::No content to send to gemini (both prompt and stdin-file were empty)."
+          exit 1
+        fi
+        echo "input lines: $(wc -l < combined-input.txt)"
+        echo "input bytes: $(wc -c < combined-input.txt)"
+
+        set +e
+        gemini --yolo --skip-trust -m "$MODEL" < combined-input.txt > "$OUTPUT" 2>gemini-stderr.log
+        rc=$?
+        if [ $rc -ne 0 ]; then
+          echo "::warning::Primary model '$MODEL' exited $rc; falling back to '$FALLBACK'."
+          echo "--- primary stderr ---"
+          cat gemini-stderr.log
+          gemini --yolo --skip-trust -m "$FALLBACK" < combined-input.txt > "$OUTPUT" 2>gemini-stderr.log
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "::error::Fallback model '$FALLBACK' also exited $rc."
+            echo "--- fallback stderr ---"
+            cat gemini-stderr.log
+            echo "--- fallback stdout ---"
+            cat "$OUTPUT"
+            exit $rc
+          fi
+        fi
+        set -e
+        echo "stdout (first 500 chars):"
+        head -c 500 "$OUTPUT"
+        echo ""

--- a/.github/actions/gemini/action.yml
+++ b/.github/actions/gemini/action.yml
@@ -50,15 +50,24 @@ runs:
         ORG: ${{ inputs.org }}
       run: |
         # Hard gate: agents must not be invocable by non-org-members.
-        # This lives inside the composite action so consumers cannot forget it.
+        # NOTE: the default GITHUB_TOKEN can only see PUBLIC org memberships.
+        # Members whose membership is private are invisible to this check
+        # and will trigger a hard fail. Make membership public on the org
+        # page (Settings → People → "Make public") to be recognized.
         if ! gh api "orgs/$ORG/members/$ACTOR" >/dev/null 2>&1; then
-          echo "::error::$ACTOR is not a member of the '$ORG' GitHub org."
-          echo "Agent invocations (Gemini) are restricted to org members. The"
-          echo "calling workflow either ran without the org/repo fork-PR"
-          echo "contributor-approval setting, or the gate is misconfigured."
+          echo "::error::$ACTOR is not a (publicly-visible) member of the '$ORG' GitHub org."
+          echo ""
+          echo "If you ARE a member but private: visit"
+          echo "https://github.com/orgs/$ORG/people and click 'Make public'"
+          echo "next to your row. The default workflow GITHUB_TOKEN cannot"
+          echo "see private memberships."
+          echo ""
+          echo "If you are not a member: agent invocations (Gemini) are"
+          echo "restricted to org members. An org member must open the PR"
+          echo "on your behalf."
           exit 1
         fi
-        echo "✓ $ACTOR is a $ORG org member."
+        echo "✓ $ACTOR is a $ORG org member (public)."
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/actions/gemini/action.yml
+++ b/.github/actions/gemini/action.yml
@@ -128,3 +128,14 @@ runs:
         echo "stdout (first 500 chars):"
         head -c 500 "$OUTPUT"
         echo ""
+
+    - name: Verify output produced
+      shell: bash
+      env:
+        OUTPUT: ${{ inputs.output-file }}
+      run: |
+        if [ ! -s "$OUTPUT" ]; then
+          echo "::error::$OUTPUT is empty or missing — gemini exited 0 but produced no content."
+          exit 1
+        fi
+        echo "✓ $OUTPUT exists ($(wc -c < "$OUTPUT") bytes)"

--- a/.github/actions/gemini/action.yml
+++ b/.github/actions/gemini/action.yml
@@ -69,7 +69,7 @@ runs:
         fi
         echo "✓ $ACTOR is a $ORG org member (public)."
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: "20"
 

--- a/.github/scripts/check-memory-structure.sh
+++ b/.github/scripts/check-memory-structure.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Structural sanity check for MEMORY.md.
+#
+# Asserts the canonical VSDD doc still contains all nine top-level Roman-
+# numeral section headings (### **I., ### **II., ..., ### **IX.). Protects
+# against accidental section deletion in PRs that touch MEMORY.md.
+set -euo pipefail
+
+MEMORY="MEMORY.md"
+
+if [ ! -f "$MEMORY" ]; then
+  echo "FAIL: $MEMORY does not exist." >&2
+  exit 1
+fi
+
+required=(I II III IV V VI VII VIII IX)
+missing=()
+
+for n in "${required[@]}"; do
+  # Match a line that begins with: ### **<roman>.
+  if ! grep -Eq "^### \*\*${n}\." "$MEMORY"; then
+    missing+=("$n")
+  fi
+done
+
+if [ "${#missing[@]}" -ne 0 ]; then
+  echo "FAIL: $MEMORY is missing required section heading(s):" >&2
+  for n in "${missing[@]}"; do
+    echo "  - ### **${n}." >&2
+  done
+  exit 1
+fi
+
+echo "OK: $MEMORY contains all 9 Roman-numeral section headings."

--- a/.github/scripts/extract-verdict.js
+++ b/.github/scripts/extract-verdict.js
@@ -1,0 +1,35 @@
+// Forgiving verdict extractor — pulls "verdict: pass|fail" out of an agent
+// response in three escalating ways, returning {verdict, body} or
+// {verdict: null, body: text} when nothing matches.
+//
+//   1. Strict YAML frontmatter at the very top of the file
+//      (---\nverdict: ...\n---)
+//   2. An embedded frontmatter block anywhere in the doc
+//   3. A bare "verdict: pass|fail" line anywhere
+//
+// Used by both pulls.yml's gemini-review and claude-review post-steps.
+// `require` it from a github-script step:
+//
+//   const { extractVerdict } = require('./.github/scripts/extract-verdict.js');
+
+function extractVerdict(text) {
+  // 1. Strict frontmatter at the top.
+  const m1 = text.match(/^\s*---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
+  if (m1) {
+    const fm = m1[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+    if (fm) return { verdict: fm[1].toLowerCase(), body: m1[2].trim() };
+  }
+  // 2. Embedded frontmatter block.
+  const m2 = text.match(/\n---\s*\n(verdict\s*:\s*(?:pass|fail)[\s\S]*?)\n---\s*\n/);
+  if (m2) {
+    const fm = m2[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+    if (fm) return { verdict: fm[1].toLowerCase(), body: text };
+  }
+  // 3. Bare 'verdict: pass|fail' anywhere.
+  const m3 = text.match(/^\s*\**\s*verdict\s*\**\s*[:=]\s*\**\s*(pass|fail)\b/im);
+  if (m3) return { verdict: m3[1].toLowerCase(), body: text };
+
+  return { verdict: null, body: text };
+}
+
+module.exports = { extractVerdict };

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -125,13 +125,13 @@ jobs:
           { printf '%s\n\n' "$PROMPT"; cat eval-input.txt; } > combined-input.txt
 
           set +e
-          gemini --yolo -m gemini-3-pro-preview < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
+          gemini --yolo --skip-trust -m gemini-3-pro-preview < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
           rc=$?
           if [ $rc -ne 0 ]; then
             echo "Gemini 3 exited with code $rc; falling back to 2.5"
             echo "--- gemini 3 stderr ---"
             cat gemini-stderr.log
-            gemini --yolo -m gemini-2.5-pro < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
+            gemini --yolo --skip-trust -m gemini-2.5-pro < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
             rc=$?
             if [ $rc -ne 0 ]; then
               echo "Gemini 2.5 exited with code $rc"

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -14,6 +14,9 @@ name: VSDD CI Meta-Review
 
 on:
   pull_request:
+    # `ready_for_review` so jobs run when a draft is promoted. Drafts are
+    # skipped at job level via the `if: ... draft != true` guard below.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - ".github/workflows/**"
       - ".github/actions/**"
@@ -49,6 +52,7 @@ jobs:
 
   prep:
     name: Prepare evaluation input
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -130,46 +130,60 @@ jobs:
             - §IX: multi-word symbol audit (camelCase/snake_case scan on code PRs).
             - Spec discipline (§VII): tech specs are discrete; goal specs are bulk.
 
-            Classify each: ENFORCED, PARTIAL, or MISSING.
+            Classify each requirement: ENFORCED, PARTIAL, or MISSING.
 
             A repo with no test suite (e.g. sw2m/philosophies — a docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A in that case, not MISSING.
 
-            Output ONLY valid JSON between exactly one <verdict>...</verdict> tag pair. No prose outside the tags.
+            # OUTPUT FORMAT (strict)
 
-            {
-              "verdict": "pass" | "fail",
-              "rationale": "one paragraph",
-              "gaps": [
-                {"title": "[ci-meta] short description (≤60 chars)", "body": "detailed explanation with VSDD section reference and concrete remediation"}
-              ]
-            }
+            Begin your output with YAML frontmatter, then prose. The frontmatter MUST be the first thing — no leading whitespace, no preamble.
 
-            verdict=pass: every applicable requirement is ENFORCED or PARTIAL with no critical gaps.
-            verdict=fail: at least one applicable requirement is MISSING, or significant PARTIAL gaps undermine VSDD.
-            For each MISSING or significant PARTIAL, add a gaps entry.
+            ---
+            verdict: pass | fail
+            rationale: |
+              one paragraph summarizing the evaluation
+            gaps:
+              - title: "[ci-meta] short description (≤60 chars)"
+                body: |
+                  detailed explanation with VSDD section reference and concrete remediation
+              - title: "..."
+                body: |
+                  ...
+            ---
 
-      - name: Parse verdict
+            (free-form summary may follow but is ignored by the parser)
+
+            Verdict semantics: `pass` answers "should this PR be approved?", not "are there zero gaps?". A `pass` with non-critical gaps listed is fine — the gaps still get tracked as issues but the meta-CI doesn't block merge.
+
+            - `verdict: pass` ⇔ gaps are nice-to-have / non-critical / partial coverage that doesn't undermine VSDD.
+            - `verdict: fail` ⇔ at least one gap is critical (a MISSING applicable requirement, or a significant PARTIAL that undermines VSDD).
+
+            For each MISSING applicable requirement, AND each significant PARTIAL, AND any nit you'd want tracked, add a `gaps` entry. The verdict tells the reader whether those gaps block merge or not.
+
+      - name: Parse frontmatter
         id: parse
         run: |
           python3 - <<'PY'
-          import re, json, sys, os
-          out = open('gemini-output.txt').read()
-          m = re.search(r'<verdict>(.*?)</verdict>', out, re.DOTALL)
+          import re, json, sys, os, yaml
+          raw = open('gemini-output.txt').read()
+          m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n(.*)$', raw, re.DOTALL)
           if not m:
-              print('ERROR: no <verdict>...</verdict> tag in gemini output', file=sys.stderr)
-              print(out, file=sys.stderr)
+              print('ERROR: no YAML frontmatter at the top of gemini output', file=sys.stderr)
+              print('--- raw ---', file=sys.stderr); print(raw, file=sys.stderr)
               sys.exit(1)
           try:
-              data = json.loads(m.group(1).strip())
-          except json.JSONDecodeError as e:
-              print(f'ERROR: invalid JSON inside <verdict>: {e}', file=sys.stderr)
-              print(m.group(1), file=sys.stderr)
-              sys.exit(1)
-          data['reviewer'] = 'gemini'
-          json.dump(data, open('gemini-eval.json', 'w'), indent=2)
+              fm = yaml.safe_load(m.group(1))
+          except yaml.YAMLError as e:
+              print(f'ERROR: invalid YAML in frontmatter: {e}', file=sys.stderr)
+              print(m.group(1), file=sys.stderr); sys.exit(1)
+          if fm.get('verdict') not in ('pass', 'fail'):
+              print(f"ERROR: verdict must be pass|fail, got {fm.get('verdict')!r}", file=sys.stderr); sys.exit(1)
+          fm['reviewer'] = 'gemini'
+          fm['summary'] = m.group(2).strip()
+          json.dump(fm, open('gemini-eval.json', 'w'), indent=2)
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f"verdict={data['verdict']}\n")
-          print(f"gemini verdict: {data['verdict']}, gaps: {len(data.get('gaps', []))}")
+              f.write(f"verdict={fm['verdict']}\n")
+          print(f"gemini verdict: {fm['verdict']}, gaps: {len(fm.get('gaps') or [])}")
           PY
 
       - uses: actions/upload-artifact@v4
@@ -194,11 +208,11 @@ jobs:
         uses: ./.github/actions/claude
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          output-file: claude-eval.json
+          output-file: claude-eval.md
           prompt: |
             You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
 
-            Read `memory-canonical.md` (the canonical VSDD doc) and `eval-input.txt` (which already bundles MEMORY.md plus every workflow and composite action in this PR — use whichever is more convenient). The repo's `.github/workflows/*.yml` and `.github/actions/*/action.yml` files are also available for direct inspection.
+            Read `memory-canonical.md` (the canonical VSDD doc) and `eval-input.txt` (which bundles MEMORY.md plus every workflow and composite action in this PR — use whichever is more convenient). `.github/workflows/*.yml` and `.github/actions/*/action.yml` are also available for direct inspection.
 
             Evaluate whether the workflows correctly enforce VSDD requirements:
             - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against §VII spec discipline.
@@ -211,24 +225,58 @@ jobs:
 
             A repo with no test suite (docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A, not MISSING.
 
-            The output file MUST be valid JSON with this exact schema:
-            {
-              "verdict": "pass" or "fail",
-              "rationale": "one paragraph",
-              "gaps": [{"title": "[ci-meta] short description ≤60 chars", "body": "detailed explanation with VSDD section reference"}],
-              "reviewer": "claude"
-            }
+            # OUTPUT FORMAT (strict)
 
-      - name: Parse verdict
+            Write a single file at the path you were told to use as `output-file`. Begin the file with YAML frontmatter:
+
+            ---
+            verdict: pass | fail
+            rationale: |
+              one paragraph
+            gaps:
+              - title: "[ci-meta] short description ≤60 chars"
+                body: |
+                  detailed explanation with VSDD section reference and concrete remediation
+              - title: "..."
+                body: |
+                  ...
+            ---
+
+            (free-form summary may follow but is ignored by the parser)
+
+            The frontmatter MUST be the first thing in the file (no leading whitespace, no preamble).
+
+            Verdict semantics: `pass` answers "should this PR be approved?", not "are there zero gaps?". A `pass` with non-critical gaps listed is fine — the gaps still get tracked but the meta-CI doesn't block merge.
+
+            - `verdict: pass` ⇔ gaps are nice-to-have / non-critical / partial coverage that doesn't undermine VSDD.
+            - `verdict: fail` ⇔ at least one gap is critical (a MISSING applicable requirement, or a significant PARTIAL that undermines VSDD).
+
+      - name: Parse frontmatter
         id: parse
         run: |
-          if [ ! -f claude-eval.json ]; then
-            echo "::error::claude-eval.json not produced"
-            exit 1
-          fi
-          VERDICT=$(python3 -c "import json; print(json.load(open('claude-eval.json'))['verdict'])")
-          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
-          echo "claude verdict: $VERDICT"
+          python3 - <<'PY'
+          import re, json, sys, os, yaml
+          if not os.path.exists('claude-eval.md'):
+              print('::error::claude-eval.md not produced'); sys.exit(1)
+          raw = open('claude-eval.md').read()
+          m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n(.*)$', raw, re.DOTALL)
+          if not m:
+              print('ERROR: no YAML frontmatter at top of claude output', file=sys.stderr)
+              print('--- raw ---', file=sys.stderr); print(raw, file=sys.stderr); sys.exit(1)
+          try:
+              fm = yaml.safe_load(m.group(1))
+          except yaml.YAMLError as e:
+              print(f'ERROR: invalid YAML in frontmatter: {e}', file=sys.stderr)
+              print(m.group(1), file=sys.stderr); sys.exit(1)
+          if fm.get('verdict') not in ('pass', 'fail'):
+              print(f"ERROR: verdict must be pass|fail, got {fm.get('verdict')!r}", file=sys.stderr); sys.exit(1)
+          fm['reviewer'] = 'claude'
+          fm['summary'] = m.group(2).strip()
+          json.dump(fm, open('claude-eval.json', 'w'), indent=2)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"verdict={fm['verdict']}\n")
+          print(f"claude verdict: {fm['verdict']}, gaps: {len(fm.get('gaps') or [])}")
+          PY
 
       - uses: actions/upload-artifact@v4
         with:
@@ -347,8 +395,56 @@ jobs:
                               f.write(f" — {url}")
                           f.write("\n")
 
+          # Stash the consensus state for the PR-review step downstream.
+          state = {
+              'verdict': 'fail' if fail else 'pass',
+              'gemini_verdict': gemini['verdict'],
+              'claude_verdict': claude['verdict'],
+              'gemini_rationale': gemini.get('rationale', ''),
+              'claude_rationale': claude.get('rationale', ''),
+              'gaps': all_gaps,
+              'opened_issue_urls': opened,
+          }
+          json.dump(state, open('consensus-state.json', 'w'), indent=2)
+
           if fail:
               print(f"\nFAIL: {len(all_gaps)} gap issue(s) opened or already open.")
               sys.exit(1)
           print("\nPASS: both reviewers agree the CI enforces VSDD correctly.")
           PY
+
+      - name: Submit consensus PR review (APPROVE / REQUEST_CHANGES)
+        if: always() && hashFiles('consensus-state.json') != '' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const state = JSON.parse(fs.readFileSync('consensus-state.json', 'utf8'));
+            const event = state.verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
+            const lines = [
+              `**VSDD CI Meta-Review** _(advisory; status check is what gates merge)_  `,
+              `_Consensus: \`${state.verdict}\` &nbsp;·&nbsp; Gemini: \`${state.gemini_verdict}\` &nbsp;·&nbsp; Claude: \`${state.claude_verdict}\`_`,
+              ``,
+              `**Gemini rationale.** ${state.gemini_rationale}`,
+              ``,
+              `**Claude rationale.** ${state.claude_rationale}`,
+              ``,
+            ];
+            if (state.gaps.length > 0) {
+              lines.push(`### Gaps (${state.gaps.length})`, ``);
+              for (let i = 0; i < state.gaps.length; i++) {
+                const g = state.gaps[i];
+                const flagged = (g.flagged_by || []).sort().join(' + ');
+                const url = state.opened_issue_urls[i];
+                lines.push(`- ${g.title} _(flagged by ${flagged})_${url ? ` — ${url}` : ''}`);
+              }
+              lines.push(``);
+            }
+            lines.push(`---`, `_Automated meta-review per MEMORY.md §I (Adversary). Two cognitive sources required to reach consensus._`);
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event,
+              body: lines.join('\n'),
+            });

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -55,7 +55,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch canonical MEMORY.md
         env:
@@ -92,7 +92,7 @@ jobs:
           } > eval-input.txt
           wc -l eval-input.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: eval-input
           path: |
@@ -106,8 +106,8 @@ jobs:
     outputs:
       verdict: ${{ steps.parse.outputs.verdict }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: eval-input
           path: ./
@@ -202,7 +202,7 @@ jobs:
           print(f"gemini verdict: {fm['verdict']}, gaps: {len(fm.get('gaps') or [])}")
           PY
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: gemini-eval
           path: gemini-eval.json
@@ -214,8 +214,8 @@ jobs:
     outputs:
       verdict: ${{ steps.parse.outputs.verdict }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: eval-input
           path: ./
@@ -345,7 +345,7 @@ jobs:
           print(f"claude verdict: {fm['verdict']}, gaps: {len(fm.get('gaps') or [])}")
           PY
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: claude-eval
           path: claude-eval.json
@@ -371,12 +371,12 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: gemini-eval
           path: ./eval/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: claude-eval
           path: ./eval/
@@ -482,7 +482,7 @@ jobs:
 
       - name: Submit consensus PR review (APPROVE / REQUEST_CHANGES)
         if: always() && hashFiles('consensus-state.json') != '' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -209,10 +209,19 @@ jobs:
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           output-file: claude-eval.md
+          # Same stdin-file pattern as Gemini — Claude has no filesystem
+          # access via the Messages API, so we embed eval-input.txt
+          # (canonical MEMORY.md + every workflow + every composite action)
+          # directly in the prompt rather than asking Claude to "read" files.
+          stdin-file: eval-input.txt
           prompt: |
             You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
 
-            Read `memory-canonical.md` (the canonical VSDD doc) and `eval-input.txt` (which bundles MEMORY.md plus every workflow and composite action in this PR — use whichever is more convenient). `.github/workflows/*.yml` and `.github/actions/*/action.yml` are also available for direct inspection.
+            The canonical VSDD doc, every CI workflow file, and every
+            composite action in this PR are EMBEDDED below in the same
+            message inside <vsdd-canonical>, <workflow path="...">, and
+            <action path="..."> tags. Do NOT look for files on disk; only
+            cite content that is present in the embedded text.
 
             Evaluate whether the workflows correctly enforce VSDD requirements:
             - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against §VII spec discipline.

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -39,8 +39,37 @@ permissions:
   id-token: write   # required by anthropics/claude-code-action for OIDC handshake
 
 jobs:
+  membership-gate:
+    name: Org-member gate
+    runs-on: ubuntu-latest
+    outputs:
+      is-member: ${{ steps.check.outputs.is-member }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.event.sender.login || github.actor }}
+        run: |
+          # Fork-PR contributor-approval setting at org+repo level already
+          # blocks unapproved external workflow runs. This step is defense in
+          # depth: even if a member-look-alike triggered the run, every agent
+          # job downstream is gated on actual sw2m org membership.
+          set +e
+          gh api "orgs/sw2m/members/$ACTOR" >/dev/null 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" = "0" ]; then
+            echo "is-member=true" >> "$GITHUB_OUTPUT"
+            echo "✓ $ACTOR is a sw2m org member; agent jobs will run."
+          else
+            echo "is-member=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ACTOR is not a sw2m org member; agent jobs (Gemini, Claude) will be skipped."
+          fi
+
   gemini-eval:
     name: Gemini VSDD CI evaluation
+    needs: [membership-gate]
+    if: needs.membership-gate.outputs.is-member == 'true'
     runs-on: ubuntu-latest
     outputs:
       verdict: ${{ steps.eval.outputs.verdict }}
@@ -175,6 +204,8 @@ jobs:
 
   claude-eval:
     name: Claude VSDD CI evaluation
+    needs: [membership-gate]
+    if: needs.membership-gate.outputs.is-member == 'true'
     runs-on: ubuntu-latest
     outputs:
       verdict: ${{ steps.eval.outputs.verdict }}

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -3,16 +3,20 @@ name: VSDD CI Meta-Review
 # Reviews CI workflow files against VSDD methodology with TWO independent
 # adversarial reviewers (Gemini + Claude). Both must reach consensus that the
 # proposed CI correctly enforces VSDD; disagreement opens an issue per gap and
-# fails the check.
+# fails the consensus check.
 #
 # Self-evaluation runs on philosophies' own PRs that touch CI files or
 # MEMORY.md. Other sw2m repos invoke via `workflow_call` to have their own CI
 # evaluated against the canonical VSDD doc.
+#
+# AI invocations are factored out into composite actions under .github/actions/
+# (`gemini`, `claude`). Search for those names to audit every place agents run.
 
 on:
   pull_request:
     paths:
       - ".github/workflows/**"
+      - ".github/actions/**"
       - "MEMORY.md"
   workflow_call:
     inputs:
@@ -36,47 +40,22 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  id-token: write   # required by anthropics/claude-code-action for OIDC handshake
+  id-token: write
 
 jobs:
-  membership-gate:
-    name: Org-member gate
-    runs-on: ubuntu-latest
-    outputs:
-      is-member: ${{ steps.check.outputs.is-member }}
-    steps:
-      - id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.event.sender.login || github.actor }}
-        run: |
-          # Fork-PR contributor-approval setting at org+repo level already
-          # blocks unapproved external workflow runs. This step is defense in
-          # depth: even if a member-look-alike triggered the run, every agent
-          # job downstream is gated on actual sw2m org membership.
-          set +e
-          gh api "orgs/sw2m/members/$ACTOR" >/dev/null 2>&1
-          rc=$?
-          set -e
-          if [ "$rc" = "0" ]; then
-            echo "is-member=true" >> "$GITHUB_OUTPUT"
-            echo "✓ $ACTOR is a sw2m org member; agent jobs will run."
-          else
-            echo "is-member=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::$ACTOR is not a sw2m org member; agent jobs (Gemini, Claude) will be skipped."
-          fi
+  # No top-level membership-gate job here — the org-member check lives inside
+  # `.github/actions/gemini` and `.github/actions/claude` so it is impossible
+  # to invoke an agent without going through it.
 
-  gemini-eval:
-    name: Gemini VSDD CI evaluation
-    needs: [membership-gate]
-    if: needs.membership-gate.outputs.is-member == 'true'
+  prep:
+    name: Prepare evaluation input
     runs-on: ubuntu-latest
-    outputs:
-      verdict: ${{ steps.eval.outputs.verdict }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Fetch canonical MEMORY.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -f MEMORY.md ] && [ "${{ inputs.memory_md_repo || 'sw2m/philosophies' }}" = "${{ github.repository }}" ]; then
             cp MEMORY.md memory-canonical.md
@@ -86,16 +65,8 @@ jobs:
               --jq '.content' | base64 -d > memory-canonical.md
           fi
           wc -l memory-canonical.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - run: npm install -g @google/gemini-cli@latest
-
-      - name: Build evaluation input
+      - name: Build eval-input.txt
         run: |
           {
             echo "<vsdd-canonical>"
@@ -108,93 +79,97 @@ jobs:
               cat "$f"
               echo "</workflow>"
             done
+            for f in .github/actions/*/action.yml; do
+              [ -f "$f" ] || continue
+              echo "<action path=\"$f\">"
+              cat "$f"
+              echo "</action>"
+            done
           } > eval-input.txt
           wc -l eval-input.txt
 
-      - name: Gemini evaluate
-        id: eval
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: eval-input
+          path: |
+            eval-input.txt
+            memory-canonical.md
+
+  gemini-eval:
+    name: Gemini VSDD CI evaluation
+    needs: [prep]
+    runs-on: ubuntu-latest
+    outputs:
+      verdict: ${{ steps.parse.outputs.verdict }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: eval-input
+          path: ./
+
+      - name: Run Gemini
+        uses: ./.github/actions/gemini
+        with:
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          stdin-file: eval-input.txt
+          output-file: gemini-output.txt
+          prompt: |
+            You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
+
+            Read the canonical VSDD doc inside <vsdd-canonical> tags.
+            Read each CI workflow file inside <workflow path="..."> tags.
+            Read each composite action file inside <action path="..."> tags.
+
+            Evaluate whether the workflows correctly enforce VSDD requirements:
+            - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against §VII spec discipline.
+            - Phase 2a (Red Gate): a mechanism that confirms tests fail before implementation lands.
+            - Phase 2b (Green Gate): tests pass after minimal implementation.
+            - 4-Result Rule (§VIII): regression set runs alongside new tests on Red AND Green gates.
+            - Phase 3: adversarial review of code changes (Gemini and/or Claude on PR diffs).
+            - §IX: multi-word symbol audit (camelCase/snake_case scan on code PRs).
+            - Spec discipline (§VII): tech specs are discrete; goal specs are bulk.
+
+            Classify each: ENFORCED, PARTIAL, or MISSING.
+
+            A repo with no test suite (e.g. sw2m/philosophies — a docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A in that case, not MISSING.
+
+            Output ONLY valid JSON between exactly one <verdict>...</verdict> tag pair. No prose outside the tags.
+
+            {
+              "verdict": "pass" | "fail",
+              "rationale": "one paragraph",
+              "gaps": [
+                {"title": "[ci-meta] short description (≤60 chars)", "body": "detailed explanation with VSDD section reference and concrete remediation"}
+              ]
+            }
+
+            verdict=pass: every applicable requirement is ENFORCED or PARTIAL with no critical gaps.
+            verdict=fail: at least one applicable requirement is MISSING, or significant PARTIAL gaps undermine VSDD.
+            For each MISSING or significant PARTIAL, add a gaps entry.
+
+      - name: Parse verdict
+        id: parse
         run: |
-          set -euo pipefail
-          PROMPT='You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
-
-          Read the canonical VSDD doc inside <vsdd-canonical> tags.
-          Read each CI workflow file inside <workflow path="..."> tags.
-
-          Evaluate whether the workflows correctly enforce VSDD requirements:
-          - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against the spec discipline rules in §VII.
-          - Phase 2a (Red Gate): a mechanism that confirms tests fail before implementation lands. May be a CI check on PRs labeled or titled `tests:` that asserts the test suite reports failures.
-          - Phase 2b (Green Gate): tests pass after minimal implementation.
-          - 4-Result Rule (§VIII): regression set runs alongside new tests on Red AND Green gates.
-          - Phase 3: adversarial review of code changes (Gemini and/or Claude on PR diffs).
-          - §IX: multi-word symbol audit (camelCase/snake_case scan on code PRs).
-          - Spec discipline (§VII): tech specs are discrete; goal specs are bulk.
-
-          For each requirement, classify: ENFORCED, PARTIAL, or MISSING.
-
-          A repo that has no test suite (e.g. a docs repo like sw2m/philosophies) cannot enforce 2a/2b/§VIII; treat those as N/A in that case, not MISSING.
-
-          Output ONLY valid JSON between exactly one <verdict>...</verdict> tag pair. No prose outside the tags.
-
-          {
-            "verdict": "pass" | "fail",
-            "rationale": "one paragraph summarizing the evaluation",
-            "gaps": [
-              {"title": "[ci-meta] short description (≤60 chars)", "body": "detailed explanation with VSDD section reference and concrete remediation"}
-            ]
-          }
-
-          verdict=pass: every applicable requirement is ENFORCED or PARTIAL with no critical gaps.
-          verdict=fail: at least one applicable requirement is MISSING, or significant PARTIAL gaps undermine VSDD.
-          For each MISSING or significant PARTIAL, add a gaps entry.'
-
-          # Build the full input as one stdin stream (prompt + content) — gemini-cli
-          # accepts either -p or stdin; mixing the two has been unreliable.
-          { printf '%s\n\n' "$PROMPT"; cat eval-input.txt; } > combined-input.txt
-
-          set +e
-          gemini --yolo --skip-trust -m gemini-3-pro-preview < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
-          rc=$?
-          if [ $rc -ne 0 ]; then
-            echo "Gemini 3 exited with code $rc; falling back to 2.5"
-            echo "--- gemini 3 stderr ---"
-            cat gemini-stderr.log
-            gemini --yolo --skip-trust -m gemini-2.5-pro < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
-            rc=$?
-            if [ $rc -ne 0 ]; then
-              echo "Gemini 2.5 exited with code $rc"
-              echo "--- gemini 2.5 stderr ---"
-              cat gemini-stderr.log
-              echo "--- gemini 2.5 stdout ---"
-              cat gemini-output.txt
-              exit $rc
-            fi
-          fi
-          set -e
-
           python3 - <<'PY'
           import re, json, sys, os
           out = open('gemini-output.txt').read()
           m = re.search(r'<verdict>(.*?)</verdict>', out, re.DOTALL)
           if not m:
-              print('ERROR: no <verdict>...</verdict> tag found in gemini output', file=sys.stderr)
-              print('--- raw output ---', file=sys.stderr)
+              print('ERROR: no <verdict>...</verdict> tag in gemini output', file=sys.stderr)
               print(out, file=sys.stderr)
               sys.exit(1)
           try:
-              eval_data = json.loads(m.group(1).strip())
+              data = json.loads(m.group(1).strip())
           except json.JSONDecodeError as e:
               print(f'ERROR: invalid JSON inside <verdict>: {e}', file=sys.stderr)
-              print('--- raw json ---', file=sys.stderr)
               print(m.group(1), file=sys.stderr)
               sys.exit(1)
-          eval_data['reviewer'] = 'gemini'
-          json.dump(eval_data, open('gemini-eval.json', 'w'), indent=2)
+          data['reviewer'] = 'gemini'
+          json.dump(data, open('gemini-eval.json', 'w'), indent=2)
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f"verdict={eval_data['verdict']}\n")
-          print(f"gemini verdict: {eval_data['verdict']}")
-          print(f"gaps: {len(eval_data.get('gaps', []))}")
+              f.write(f"verdict={data['verdict']}\n")
+          print(f"gemini verdict: {data['verdict']}, gaps: {len(data.get('gaps', []))}")
           PY
 
       - uses: actions/upload-artifact@v4
@@ -204,36 +179,26 @@ jobs:
 
   claude-eval:
     name: Claude VSDD CI evaluation
-    needs: [membership-gate]
-    if: needs.membership-gate.outputs.is-member == 'true'
+    needs: [prep]
     runs-on: ubuntu-latest
     outputs:
-      verdict: ${{ steps.eval.outputs.verdict }}
+      verdict: ${{ steps.parse.outputs.verdict }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Fetch canonical MEMORY.md
-        run: |
-          if [ -f MEMORY.md ] && [ "${{ inputs.memory_md_repo || 'sw2m/philosophies' }}" = "${{ github.repository }}" ]; then
-            cp MEMORY.md memory-canonical.md
-          else
-            gh api \
-              "repos/${{ inputs.memory_md_repo || 'sw2m/philosophies' }}/contents/MEMORY.md?ref=${{ inputs.memory_md_ref || 'main' }}" \
-              --jq '.content' | base64 -d > memory-canonical.md
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Claude evaluate
-        id: eval
-        uses: anthropics/claude-code-action@v1
+      - uses: actions/download-artifact@v4
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          name: eval-input
+          path: ./
+
+      - name: Run Claude
+        uses: ./.github/actions/claude
+        with:
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          output-file: claude-eval.json
           prompt: |
             You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
 
-            Read `memory-canonical.md` (the canonical VSDD doc).
-            Read each `.github/workflows/*.yml` file in this repo.
+            Read `memory-canonical.md` (the canonical VSDD doc) and `eval-input.txt` (which already bundles MEMORY.md plus every workflow and composite action in this PR — use whichever is more convenient). The repo's `.github/workflows/*.yml` and `.github/actions/*/action.yml` files are also available for direct inspection.
 
             Evaluate whether the workflows correctly enforce VSDD requirements:
             - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against §VII spec discipline.
@@ -244,9 +209,9 @@ jobs:
             - §IX: multi-word symbol audit.
             - Spec discipline (§VII): tech specs are discrete.
 
-            A repo that has no test suite (docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A, not MISSING.
+            A repo with no test suite (docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A, not MISSING.
 
-            Write your evaluation to `claude-eval.json` in the repo root with this exact schema:
+            The output file MUST be valid JSON with this exact schema:
             {
               "verdict": "pass" or "fail",
               "rationale": "one paragraph",
@@ -254,13 +219,11 @@ jobs:
               "reviewer": "claude"
             }
 
-            Do NOT commit, push, or open PRs. Just write the file. The CI workflow will read it.
-
-      - name: Set verdict output
+      - name: Parse verdict
         id: parse
         run: |
           if [ ! -f claude-eval.json ]; then
-            echo "ERROR: claude-eval.json not produced by Claude" >&2
+            echo "::error::claude-eval.json not produced"
             exit 1
           fi
           VERDICT=$(python3 -c "import json; print(json.load(open('claude-eval.json'))['verdict'])")
@@ -285,29 +248,19 @@ jobs:
           echo "gemini-eval: $GEMINI_RESULT"
           echo "claude-eval: $CLAUDE_RESULT"
           fail=0
-          if [ "$GEMINI_RESULT" != "success" ]; then
-            echo "::error::Gemini reviewer did not complete successfully ($GEMINI_RESULT)."
-            fail=1
-          fi
-          if [ "$CLAUDE_RESULT" != "success" ]; then
-            echo "::error::Claude reviewer did not complete successfully ($CLAUDE_RESULT)."
-            fail=1
-          fi
+          [ "$GEMINI_RESULT" != "success" ] && { echo "::error::Gemini reviewer did not complete successfully ($GEMINI_RESULT)."; fail=1; }
+          [ "$CLAUDE_RESULT" != "success" ] && { echo "::error::Claude reviewer did not complete successfully ($CLAUDE_RESULT)."; fail=1; }
           if [ "$fail" = "1" ]; then
             echo ""
-            echo "Both reviewers must complete successfully before consensus can be computed."
-            echo "If a reviewer is failing on quota, billing, or auth, fix the upstream issue —"
-            echo "the meta-CI deliberately does not let a missing reviewer count as 'pass'."
+            echo "Both reviewers must complete before consensus. A missing reviewer must not count as 'pass'."
             exit 1
           fi
 
       - uses: actions/checkout@v4
-
       - uses: actions/download-artifact@v4
         with:
           name: gemini-eval
           path: ./eval/
-
       - uses: actions/download-artifact@v4
         with:
           name: claude-eval
@@ -330,19 +283,13 @@ jobs:
           print()
           print(f"gemini rationale: {gemini.get('rationale', '')}")
           print(f"claude rationale: {claude.get('rationale', '')}")
-          print()
 
-          # Consensus rules:
-          # - Both pass with empty gaps → CI passes, no issues opened.
-          # - Either fails → CI fails; open issues for the union of gaps (deduped).
-          # - One pass + one fail → CI fails (no consensus); issues from the failing reviewer.
           fail = gemini['verdict'] == 'fail' or claude['verdict'] == 'fail'
 
           all_gaps = []
           for g in gemini.get('gaps', []):
               all_gaps.append({**g, 'flagged_by': ['gemini']})
           for g in claude.get('gaps', []):
-              # Dedupe by normalized title
               norm = re.sub(r'\W+', ' ', g['title'].lower()).strip()
               merged = False
               for existing in all_gaps:
@@ -353,9 +300,7 @@ jobs:
               if not merged:
                   all_gaps.append({**g, 'flagged_by': ['claude']})
 
-          pr_number = os.environ.get('PR_NUMBER', '')
           pr_url = os.environ.get('PR_URL', '')
-
           opened = []
           for g in all_gaps:
               flagged_by = ' + '.join(sorted(g['flagged_by']))
@@ -365,7 +310,6 @@ jobs:
                   f"---\n"
                   f"PR triggering this evaluation: {pr_url or '(self-evaluation)'}\n"
               )
-              # Idempotency: skip if a similar open issue already exists
               search = subprocess.run(
                   ['gh', 'issue', 'list', '--state', 'open', '--search', g['title'], '--json', 'number,title'],
                   capture_output=True, text=True, check=True,
@@ -374,26 +318,19 @@ jobs:
               if any(item['title'] == g['title'] for item in existing):
                   print(f"  skip (already open): {g['title']}")
                   continue
-              # Create
               r = subprocess.run(
                   ['gh', 'issue', 'create', '--title', g['title'], '--body', body, '--label', 'ci-meta'],
                   capture_output=True, text=True,
               )
-              if r.returncode == 0:
-                  url = r.stdout.strip().splitlines()[-1]
-                  print(f"  opened: {url}")
-                  opened.append(url)
-              else:
-                  # Label may not exist; retry without label
-                  r2 = subprocess.run(
+              if r.returncode != 0:
+                  r = subprocess.run(
                       ['gh', 'issue', 'create', '--title', g['title'], '--body', body],
                       capture_output=True, text=True, check=True,
                   )
-                  url = r2.stdout.strip().splitlines()[-1]
-                  print(f"  opened: {url}  (label 'ci-meta' did not exist; create it manually if you want filtering)")
-                  opened.append(url)
+              url = r.stdout.strip().splitlines()[-1]
+              print(f"  opened: {url}")
+              opened.append(url)
 
-          # Summary for the GitHub Actions run
           summary = os.environ.get('GITHUB_STEP_SUMMARY')
           if summary:
               with open(summary, 'a') as f:
@@ -411,8 +348,7 @@ jobs:
                           f.write("\n")
 
           if fail:
-              print(f"\nFAIL: consensus not reached. {len(all_gaps)} gap issue(s) opened or already open.")
+              print(f"\nFAIL: {len(all_gaps)} gap issue(s) opened or already open.")
               sys.exit(1)
-          else:
-              print("\nPASS: both reviewers agree the CI enforces VSDD correctly.")
+          print("\nPASS: both reviewers agree the CI enforces VSDD correctly.")
           PY

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -169,7 +169,8 @@ jobs:
         run: |
           python3 - <<'PY'
           import re, json, sys, os, yaml
-          raw = open('gemini-output.txt').read()
+          with open('gemini-output.txt') as f:
+              raw = f.read()
           m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n?(.*)$', raw, re.DOTALL)
           fm = None
           summary = raw
@@ -196,7 +197,8 @@ jobs:
               print('--- raw output ---', file=sys.stderr); print(raw, file=sys.stderr); sys.exit(1)
           fm['reviewer'] = 'gemini'
           fm['summary'] = summary
-          json.dump(fm, open('gemini-eval.json', 'w'), indent=2)
+          with open('gemini-eval.json', 'w') as f:
+              json.dump(fm, f, indent=2)
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"verdict={fm['verdict']}\n")
           print(f"gemini verdict: {fm['verdict']}, gaps: {len(fm.get('gaps') or [])}")
@@ -309,7 +311,8 @@ jobs:
           import re, json, sys, os, yaml
           if not os.path.exists('claude-eval.md'):
               print('::error::claude-eval.md not produced'); sys.exit(1)
-          raw = open('claude-eval.md').read()
+          with open('claude-eval.md') as f:
+              raw = f.read()
           # Primary: strict frontmatter block at the top.
           m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n?(.*)$', raw, re.DOTALL)
           fm = None
@@ -339,7 +342,8 @@ jobs:
               print('--- raw output ---', file=sys.stderr); print(raw, file=sys.stderr); sys.exit(1)
           fm['reviewer'] = 'claude'
           fm['summary'] = summary
-          json.dump(fm, open('claude-eval.json', 'w'), indent=2)
+          with open('claude-eval.json', 'w') as f:
+              json.dump(fm, f, indent=2)
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"verdict={fm['verdict']}\n")
           print(f"claude verdict: {fm['verdict']}, gaps: {len(fm.get('gaps') or [])}")
@@ -355,6 +359,13 @@ jobs:
     needs: [gemini-eval, claude-eval]
     runs-on: ubuntu-latest
     if: always()
+    # Serialize issue creation across concurrent runs of this workflow.
+    # Without this, two concurrent PRs identifying the same gap can both
+    # see "no existing issue" and create duplicates (TOCTOU between
+    # `gh issue list` and `gh issue create`).
+    concurrency:
+      group: ci-meta-consensus-${{ github.repository }}
+      cancel-in-progress: false
     steps:
       - name: Fail fast if either reviewer errored
         run: |
@@ -390,8 +401,10 @@ jobs:
           python3 - <<'PY'
           import json, os, re, subprocess, sys
 
-          gemini = json.load(open('eval/gemini-eval.json'))
-          claude = json.load(open('eval/claude-eval.json'))
+          with open('eval/gemini-eval.json') as f:
+              gemini = json.load(f)
+          with open('eval/claude-eval.json') as f:
+              claude = json.load(f)
 
           print(f"gemini: verdict={gemini['verdict']}, gaps={len(gemini.get('gaps', []))}")
           print(f"claude: verdict={claude['verdict']}, gaps={len(claude.get('gaps', []))}")
@@ -472,7 +485,8 @@ jobs:
               'gaps': all_gaps,
               'opened_issue_urls': opened,
           }
-          json.dump(state, open('consensus-state.json', 'w'), indent=2)
+          with open('consensus-state.json', 'w') as f:
+              json.dump(state, f, indent=2)
 
           if fail:
               print(f"\nFAIL: {len(all_gaps)} gap issue(s) opened or already open.")

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -166,20 +166,32 @@ jobs:
           python3 - <<'PY'
           import re, json, sys, os, yaml
           raw = open('gemini-output.txt').read()
-          m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n(.*)$', raw, re.DOTALL)
-          if not m:
-              print('ERROR: no YAML frontmatter at the top of gemini output', file=sys.stderr)
-              print('--- raw ---', file=sys.stderr); print(raw, file=sys.stderr)
-              sys.exit(1)
-          try:
-              fm = yaml.safe_load(m.group(1))
-          except yaml.YAMLError as e:
-              print(f'ERROR: invalid YAML in frontmatter: {e}', file=sys.stderr)
-              print(m.group(1), file=sys.stderr); sys.exit(1)
-          if fm.get('verdict') not in ('pass', 'fail'):
-              print(f"ERROR: verdict must be pass|fail, got {fm.get('verdict')!r}", file=sys.stderr); sys.exit(1)
+          m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n?(.*)$', raw, re.DOTALL)
+          fm = None
+          summary = raw
+          if m:
+              try:
+                  fm = yaml.safe_load(m.group(1))
+                  summary = m.group(2).strip()
+              except yaml.YAMLError as e:
+                  print(f'WARN: frontmatter present but invalid YAML: {e}', file=sys.stderr)
+                  fm = None
+          if fm is None or fm.get('verdict') not in ('pass', 'fail'):
+              m2 = re.search(r'\n---\s*\n(verdict\s*:\s*(?:pass|fail).*?)\n---\s*\n', raw, re.DOTALL)
+              if m2:
+                  try:
+                      fm = yaml.safe_load(m2.group(1))
+                  except yaml.YAMLError:
+                      fm = None
+          if fm is None or fm.get('verdict') not in ('pass', 'fail'):
+              m3 = re.search(r'(?im)^\s*\**\s*verdict\s*\**\s*[:=]\s*\**\s*(pass|fail)\b', raw)
+              if m3:
+                  fm = {'verdict': m3.group(1).lower(), 'rationale': '(verdict extracted from prose; frontmatter missing)', 'gaps': []}
+          if fm is None or fm.get('verdict') not in ('pass', 'fail'):
+              print('::error::Could not extract a verdict from gemini output (no frontmatter, no fallback match).', file=sys.stderr)
+              print('--- raw output ---', file=sys.stderr); print(raw, file=sys.stderr); sys.exit(1)
           fm['reviewer'] = 'gemini'
-          fm['summary'] = m.group(2).strip()
+          fm['summary'] = summary
           json.dump(fm, open('gemini-eval.json', 'w'), indent=2)
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"verdict={fm['verdict']}\n")
@@ -215,6 +227,32 @@ jobs:
           # directly in the prompt rather than asking Claude to "read" files.
           stdin-file: eval-input.txt
           prompt: |
+            # CRITICAL OUTPUT FORMAT (read this FIRST)
+
+            Your response MUST start, on the very first line, with exactly the three characters `---` (no leading whitespace, no preamble, no markdown heading), then a YAML block, then `---` to close, then optional prose.
+
+            Concrete example of an acceptable response:
+
+            ```
+            ---
+            verdict: pass
+            rationale: |
+              All applicable VSDD requirements are enforced. Phase 1c, 3, §VII,
+              §IX are implemented; 2a/2b/§VIII are N/A on a docs repo.
+            gaps:
+              - title: "[ci-meta] sample non-blocking gap"
+                body: |
+                  Optional improvement that doesn't block merge.
+            ---
+
+            (any free-form summary may follow here, ignored by the parser)
+            ```
+
+            If you do not produce frontmatter as your first output, the workflow
+            will fail and your analysis will be discarded. This is non-negotiable.
+
+            # TASK
+
             You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
 
             The canonical VSDD doc, every CI workflow file, and every
@@ -268,19 +306,35 @@ jobs:
           if not os.path.exists('claude-eval.md'):
               print('::error::claude-eval.md not produced'); sys.exit(1)
           raw = open('claude-eval.md').read()
-          m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n(.*)$', raw, re.DOTALL)
-          if not m:
-              print('ERROR: no YAML frontmatter at top of claude output', file=sys.stderr)
-              print('--- raw ---', file=sys.stderr); print(raw, file=sys.stderr); sys.exit(1)
-          try:
-              fm = yaml.safe_load(m.group(1))
-          except yaml.YAMLError as e:
-              print(f'ERROR: invalid YAML in frontmatter: {e}', file=sys.stderr)
-              print(m.group(1), file=sys.stderr); sys.exit(1)
-          if fm.get('verdict') not in ('pass', 'fail'):
-              print(f"ERROR: verdict must be pass|fail, got {fm.get('verdict')!r}", file=sys.stderr); sys.exit(1)
+          # Primary: strict frontmatter block at the top.
+          m = re.match(r'^\s*---\s*\n(.*?)\n---\s*\n?(.*)$', raw, re.DOTALL)
+          fm = None
+          summary = raw
+          if m:
+              try:
+                  fm = yaml.safe_load(m.group(1))
+                  summary = m.group(2).strip()
+              except yaml.YAMLError as e:
+                  print(f'WARN: frontmatter present but invalid YAML: {e}', file=sys.stderr)
+                  fm = None
+          # Fallback 1: an embedded frontmatter block anywhere in the doc.
+          if fm is None or fm.get('verdict') not in ('pass', 'fail'):
+              m2 = re.search(r'\n---\s*\n(verdict\s*:\s*(?:pass|fail).*?)\n---\s*\n', raw, re.DOTALL)
+              if m2:
+                  try:
+                      fm = yaml.safe_load(m2.group(1))
+                  except yaml.YAMLError:
+                      fm = None
+          # Fallback 2: scan for a bare 'verdict: pass|fail' line.
+          if fm is None or fm.get('verdict') not in ('pass', 'fail'):
+              m3 = re.search(r'(?im)^\s*\**\s*verdict\s*\**\s*[:=]\s*\**\s*(pass|fail)\b', raw)
+              if m3:
+                  fm = {'verdict': m3.group(1).lower(), 'rationale': '(verdict extracted from prose; frontmatter missing)', 'gaps': []}
+          if fm is None or fm.get('verdict') not in ('pass', 'fail'):
+              print('::error::Could not extract a verdict from claude output (no frontmatter, no fallback match).', file=sys.stderr)
+              print('--- raw output ---', file=sys.stderr); print(raw, file=sys.stderr); sys.exit(1)
           fm['reviewer'] = 'claude'
-          fm['summary'] = m.group(2).strip()
+          fm['summary'] = summary
           json.dump(fm, open('claude-eval.json', 'w'), indent=2)
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"verdict={fm['verdict']}\n")

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -36,6 +36,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC handshake
 
 jobs:
   gemini-eval:

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -1,0 +1,342 @@
+name: VSDD CI Meta-Review
+
+# Reviews CI workflow files against VSDD methodology with TWO independent
+# adversarial reviewers (Gemini + Claude). Both must reach consensus that the
+# proposed CI correctly enforces VSDD; disagreement opens an issue per gap and
+# fails the check.
+#
+# Self-evaluation runs on philosophies' own PRs that touch CI files or
+# MEMORY.md. Other sw2m repos invoke via `workflow_call` to have their own CI
+# evaluated against the canonical VSDD doc.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "MEMORY.md"
+  workflow_call:
+    inputs:
+      memory_md_repo:
+        description: "Repo to fetch MEMORY.md from. Defaults to sw2m/philosophies."
+        type: string
+        required: false
+        default: "sw2m/philosophies"
+      memory_md_ref:
+        description: "Branch/tag/SHA on memory_md_repo. Defaults to main."
+        type: string
+        required: false
+        default: "main"
+    secrets:
+      GEMINI_API_KEY:
+        required: true
+      ANTHROPIC_API_KEY:
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  gemini-eval:
+    name: Gemini VSDD CI evaluation
+    runs-on: ubuntu-latest
+    outputs:
+      verdict: ${{ steps.eval.outputs.verdict }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch canonical MEMORY.md
+        run: |
+          if [ -f MEMORY.md ] && [ "${{ inputs.memory_md_repo || 'sw2m/philosophies' }}" = "${{ github.repository }}" ]; then
+            cp MEMORY.md memory-canonical.md
+          else
+            gh api \
+              "repos/${{ inputs.memory_md_repo || 'sw2m/philosophies' }}/contents/MEMORY.md?ref=${{ inputs.memory_md_ref || 'main' }}" \
+              --jq '.content' | base64 -d > memory-canonical.md
+          fi
+          wc -l memory-canonical.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm install -g @google/gemini-cli@latest
+
+      - name: Build evaluation input
+        run: |
+          {
+            echo "<vsdd-canonical>"
+            cat memory-canonical.md
+            echo "</vsdd-canonical>"
+            echo ""
+            for f in .github/workflows/*.yml; do
+              [ -f "$f" ] || continue
+              echo "<workflow path=\"$f\">"
+              cat "$f"
+              echo "</workflow>"
+            done
+          } > eval-input.txt
+          wc -l eval-input.txt
+
+      - name: Gemini evaluate
+        id: eval
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          set -euo pipefail
+          PROMPT='You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
+
+          Read the canonical VSDD doc inside <vsdd-canonical> tags.
+          Read each CI workflow file inside <workflow path="..."> tags.
+
+          Evaluate whether the workflows correctly enforce VSDD requirements:
+          - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against the spec discipline rules in §VII.
+          - Phase 2a (Red Gate): a mechanism that confirms tests fail before implementation lands. May be a CI check on PRs labeled or titled `tests:` that asserts the test suite reports failures.
+          - Phase 2b (Green Gate): tests pass after minimal implementation.
+          - 4-Result Rule (§VIII): regression set runs alongside new tests on Red AND Green gates.
+          - Phase 3: adversarial review of code changes (Gemini and/or Claude on PR diffs).
+          - §IX: multi-word symbol audit (camelCase/snake_case scan on code PRs).
+          - Spec discipline (§VII): tech specs are discrete; goal specs are bulk.
+
+          For each requirement, classify: ENFORCED, PARTIAL, or MISSING.
+
+          A repo that has no test suite (e.g. a docs repo like sw2m/philosophies) cannot enforce 2a/2b/§VIII; treat those as N/A in that case, not MISSING.
+
+          Output ONLY valid JSON between exactly one <verdict>...</verdict> tag pair. No prose outside the tags.
+
+          {
+            "verdict": "pass" | "fail",
+            "rationale": "one paragraph summarizing the evaluation",
+            "gaps": [
+              {"title": "[ci-meta] short description (≤60 chars)", "body": "detailed explanation with VSDD section reference and concrete remediation"}
+            ]
+          }
+
+          verdict=pass: every applicable requirement is ENFORCED or PARTIAL with no critical gaps.
+          verdict=fail: at least one applicable requirement is MISSING, or significant PARTIAL gaps undermine VSDD.
+          For each MISSING or significant PARTIAL, add a gaps entry.'
+
+          (gemini --yolo -m gemini-3-pro-preview -p "$PROMPT" < eval-input.txt > gemini-output.txt 2>gemini-stderr.log) || \
+            gemini --yolo -m gemini-2.5-pro -p "$PROMPT" < eval-input.txt > gemini-output.txt 2>gemini-stderr.log
+
+          python3 - <<'PY'
+          import re, json, sys, os
+          out = open('gemini-output.txt').read()
+          m = re.search(r'<verdict>(.*?)</verdict>', out, re.DOTALL)
+          if not m:
+              print('ERROR: no <verdict>...</verdict> tag found in gemini output', file=sys.stderr)
+              print('--- raw output ---', file=sys.stderr)
+              print(out, file=sys.stderr)
+              sys.exit(1)
+          try:
+              eval_data = json.loads(m.group(1).strip())
+          except json.JSONDecodeError as e:
+              print(f'ERROR: invalid JSON inside <verdict>: {e}', file=sys.stderr)
+              print('--- raw json ---', file=sys.stderr)
+              print(m.group(1), file=sys.stderr)
+              sys.exit(1)
+          eval_data['reviewer'] = 'gemini'
+          json.dump(eval_data, open('gemini-eval.json', 'w'), indent=2)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"verdict={eval_data['verdict']}\n")
+          print(f"gemini verdict: {eval_data['verdict']}")
+          print(f"gaps: {len(eval_data.get('gaps', []))}")
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gemini-eval
+          path: gemini-eval.json
+
+  claude-eval:
+    name: Claude VSDD CI evaluation
+    runs-on: ubuntu-latest
+    outputs:
+      verdict: ${{ steps.eval.outputs.verdict }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch canonical MEMORY.md
+        run: |
+          if [ -f MEMORY.md ] && [ "${{ inputs.memory_md_repo || 'sw2m/philosophies' }}" = "${{ github.repository }}" ]; then
+            cp MEMORY.md memory-canonical.md
+          else
+            gh api \
+              "repos/${{ inputs.memory_md_repo || 'sw2m/philosophies' }}/contents/MEMORY.md?ref=${{ inputs.memory_md_ref || 'main' }}" \
+              --jq '.content' | base64 -d > memory-canonical.md
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Claude evaluate
+        id: eval
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
+
+            Read `memory-canonical.md` (the canonical VSDD doc).
+            Read each `.github/workflows/*.yml` file in this repo.
+
+            Evaluate whether the workflows correctly enforce VSDD requirements:
+            - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against §VII spec discipline.
+            - Phase 2a (Red Gate): tests fail before implementation; CI confirms.
+            - Phase 2b (Green Gate): tests pass after minimal impl.
+            - 4-Result Rule (§VIII): regression set runs alongside new tests on Red AND Green gates.
+            - Phase 3: adversarial review of code changes.
+            - §IX: multi-word symbol audit.
+            - Spec discipline (§VII): tech specs are discrete.
+
+            A repo that has no test suite (docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A, not MISSING.
+
+            Write your evaluation to `claude-eval.json` in the repo root with this exact schema:
+            {
+              "verdict": "pass" or "fail",
+              "rationale": "one paragraph",
+              "gaps": [{"title": "[ci-meta] short description ≤60 chars", "body": "detailed explanation with VSDD section reference"}],
+              "reviewer": "claude"
+            }
+
+            Do NOT commit, push, or open PRs. Just write the file. The CI workflow will read it.
+
+      - name: Set verdict output
+        id: parse
+        run: |
+          if [ ! -f claude-eval.json ]; then
+            echo "ERROR: claude-eval.json not produced by Claude" >&2
+            exit 1
+          fi
+          VERDICT=$(python3 -c "import json; print(json.load(open('claude-eval.json'))['verdict'])")
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          echo "claude verdict: $VERDICT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: claude-eval
+          path: claude-eval.json
+
+  consensus:
+    name: Consensus + open issues for gaps
+    needs: [gemini-eval, claude-eval]
+    runs-on: ubuntu-latest
+    if: always() && (needs.gemini-eval.result == 'success' || needs.claude-eval.result == 'success')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: gemini-eval
+          path: ./eval/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: claude-eval
+          path: ./eval/
+
+      - name: Reach consensus + open gap issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          python3 - <<'PY'
+          import json, os, re, subprocess, sys
+
+          gemini = json.load(open('eval/gemini-eval.json'))
+          claude = json.load(open('eval/claude-eval.json'))
+
+          print(f"gemini: verdict={gemini['verdict']}, gaps={len(gemini.get('gaps', []))}")
+          print(f"claude: verdict={claude['verdict']}, gaps={len(claude.get('gaps', []))}")
+          print()
+          print(f"gemini rationale: {gemini.get('rationale', '')}")
+          print(f"claude rationale: {claude.get('rationale', '')}")
+          print()
+
+          # Consensus rules:
+          # - Both pass with empty gaps → CI passes, no issues opened.
+          # - Either fails → CI fails; open issues for the union of gaps (deduped).
+          # - One pass + one fail → CI fails (no consensus); issues from the failing reviewer.
+          fail = gemini['verdict'] == 'fail' or claude['verdict'] == 'fail'
+
+          all_gaps = []
+          for g in gemini.get('gaps', []):
+              all_gaps.append({**g, 'flagged_by': ['gemini']})
+          for g in claude.get('gaps', []):
+              # Dedupe by normalized title
+              norm = re.sub(r'\W+', ' ', g['title'].lower()).strip()
+              merged = False
+              for existing in all_gaps:
+                  if re.sub(r'\W+', ' ', existing['title'].lower()).strip() == norm:
+                      existing['flagged_by'].append('claude')
+                      merged = True
+                      break
+              if not merged:
+                  all_gaps.append({**g, 'flagged_by': ['claude']})
+
+          pr_number = os.environ.get('PR_NUMBER', '')
+          pr_url = os.environ.get('PR_URL', '')
+
+          opened = []
+          for g in all_gaps:
+              flagged_by = ' + '.join(sorted(g['flagged_by']))
+              body = (
+                  f"_Flagged by **{flagged_by}** in the VSDD CI meta-review._\n\n"
+                  f"{g['body']}\n\n"
+                  f"---\n"
+                  f"PR triggering this evaluation: {pr_url or '(self-evaluation)'}\n"
+              )
+              # Idempotency: skip if a similar open issue already exists
+              search = subprocess.run(
+                  ['gh', 'issue', 'list', '--state', 'open', '--search', g['title'], '--json', 'number,title'],
+                  capture_output=True, text=True, check=True,
+              )
+              existing = json.loads(search.stdout)
+              if any(item['title'] == g['title'] for item in existing):
+                  print(f"  skip (already open): {g['title']}")
+                  continue
+              # Create
+              r = subprocess.run(
+                  ['gh', 'issue', 'create', '--title', g['title'], '--body', body, '--label', 'ci-meta'],
+                  capture_output=True, text=True,
+              )
+              if r.returncode == 0:
+                  url = r.stdout.strip().splitlines()[-1]
+                  print(f"  opened: {url}")
+                  opened.append(url)
+              else:
+                  # Label may not exist; retry without label
+                  r2 = subprocess.run(
+                      ['gh', 'issue', 'create', '--title', g['title'], '--body', body],
+                      capture_output=True, text=True, check=True,
+                  )
+                  url = r2.stdout.strip().splitlines()[-1]
+                  print(f"  opened: {url}  (label 'ci-meta' did not exist; create it manually if you want filtering)")
+                  opened.append(url)
+
+          # Summary for the GitHub Actions run
+          summary = os.environ.get('GITHUB_STEP_SUMMARY')
+          if summary:
+              with open(summary, 'a') as f:
+                  f.write(f"# VSDD CI Meta-Review\n\n")
+                  f.write(f"- Gemini: **{gemini['verdict']}**\n")
+                  f.write(f"- Claude: **{claude['verdict']}**\n")
+                  f.write(f"- Consensus: **{'fail' if fail else 'pass'}**\n\n")
+                  if all_gaps:
+                      f.write(f"## Gaps ({len(all_gaps)})\n\n")
+                      for g, url in zip(all_gaps, opened or [None] * len(all_gaps)):
+                          flagged_by = ' + '.join(sorted(g['flagged_by']))
+                          f.write(f"- {g['title']} _(flagged by {flagged_by})_")
+                          if url:
+                              f.write(f" — {url}")
+                          f.write("\n")
+
+          if fail:
+              print(f"\nFAIL: consensus not reached. {len(all_gaps)} gap issue(s) opened or already open.")
+              sys.exit(1)
+          else:
+              print("\nPASS: both reviewers agree the CI enforces VSDD correctly.")
+          PY

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -120,8 +120,29 @@ jobs:
           verdict=fail: at least one applicable requirement is MISSING, or significant PARTIAL gaps undermine VSDD.
           For each MISSING or significant PARTIAL, add a gaps entry.'
 
-          (gemini --yolo -m gemini-3-pro-preview -p "$PROMPT" < eval-input.txt > gemini-output.txt 2>gemini-stderr.log) || \
-            gemini --yolo -m gemini-2.5-pro -p "$PROMPT" < eval-input.txt > gemini-output.txt 2>gemini-stderr.log
+          # Build the full input as one stdin stream (prompt + content) — gemini-cli
+          # accepts either -p or stdin; mixing the two has been unreliable.
+          { printf '%s\n\n' "$PROMPT"; cat eval-input.txt; } > combined-input.txt
+
+          set +e
+          gemini --yolo -m gemini-3-pro-preview < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "Gemini 3 exited with code $rc; falling back to 2.5"
+            echo "--- gemini 3 stderr ---"
+            cat gemini-stderr.log
+            gemini --yolo -m gemini-2.5-pro < combined-input.txt > gemini-output.txt 2>gemini-stderr.log
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "Gemini 2.5 exited with code $rc"
+              echo "--- gemini 2.5 stderr ---"
+              cat gemini-stderr.log
+              echo "--- gemini 2.5 stdout ---"
+              cat gemini-output.txt
+              exit $rc
+            fi
+          fi
+          set -e
 
           python3 - <<'PY'
           import re, json, sys, os

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -245,8 +245,31 @@ jobs:
     name: Consensus + open issues for gaps
     needs: [gemini-eval, claude-eval]
     runs-on: ubuntu-latest
-    if: always() && (needs.gemini-eval.result == 'success' || needs.claude-eval.result == 'success')
+    if: always()
     steps:
+      - name: Fail fast if either reviewer errored
+        run: |
+          GEMINI_RESULT="${{ needs.gemini-eval.result }}"
+          CLAUDE_RESULT="${{ needs.claude-eval.result }}"
+          echo "gemini-eval: $GEMINI_RESULT"
+          echo "claude-eval: $CLAUDE_RESULT"
+          fail=0
+          if [ "$GEMINI_RESULT" != "success" ]; then
+            echo "::error::Gemini reviewer did not complete successfully ($GEMINI_RESULT)."
+            fail=1
+          fi
+          if [ "$CLAUDE_RESULT" != "success" ]; then
+            echo "::error::Claude reviewer did not complete successfully ($CLAUDE_RESULT)."
+            fail=1
+          fi
+          if [ "$fail" = "1" ]; then
+            echo ""
+            echo "Both reviewers must complete successfully before consensus can be computed."
+            echo "If a reviewer is failing on quota, billing, or auth, fix the upstream issue —"
+            echo "the meta-CI deliberately does not let a missing reviewer count as 'pass'."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -45,11 +45,15 @@ jobs:
             - Properties claimed as "testable only" that should be provable
             - Purity-boundary violations
             - Verification-tool mismatches
-            - Spec discipline violations (§VII): if this is a tech-spec
-              issue, does it cover exactly one technical problem? Bundled
-              tech specs (multiple problems in one issue body) violate
-              the discrete-tech-spec rule. Goal specs may carry many
-              goals — that's fine, do not flag.
+            - Spec discipline violations (§VII), both sides of the rule:
+              * Tech-spec issue: does it cover exactly ONE discrete
+                technical problem? Bundled tech specs (multiple
+                technical problems in one issue body) violate §VII.
+              * Goal-spec issue: does it stay focused on goals (WHAT
+                must be true) without leaking technical / implementation
+                content (HOW)? Goal specs may have many goals (that's
+                fine, do not flag breadth), but they must not include
+                solution design — that belongs in tech specs.
 
           Output rules:
             - Be terse. Bullet points only. No preamble.

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -77,7 +77,7 @@ jobs:
 
           run_gemini() {
             local model="$1"
-            gemini --yolo --model "$model" \
+            gemini --yolo --skip-trust --model "$model" \
               --prompt "$(cat /tmp/vsdd/prompt.txt)" \
               > /tmp/vsdd/review.md 2> /tmp/vsdd/err.log
           }

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -17,8 +17,33 @@ permissions:
   contents: read
 
 jobs:
+  membership-gate:
+    name: Org-member gate
+    runs-on: ubuntu-latest
+    outputs:
+      is-member: ${{ steps.check.outputs.is-member }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.event.sender.login || github.actor }}
+        run: |
+          set +e
+          gh api "orgs/sw2m/members/$ACTOR" >/dev/null 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" = "0" ]; then
+            echo "is-member=true" >> "$GITHUB_OUTPUT"
+            echo "✓ $ACTOR is a sw2m org member; agent jobs will run."
+          else
+            echo "is-member=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ACTOR is not a sw2m org member; agent job will be skipped."
+          fi
+
   vsdd-issue-review:
     name: Gemini VSDD Phase 1c review
+    needs: [membership-gate]
+    if: needs.membership-gate.outputs.is-member == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (for MEMORY.md context)

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,112 @@
+name: VSDD Issue Review (Phase 1c)
+
+# Advisory only — never gates anything.
+# Reads new/edited issues, runs an adversarial Gemini pass looking for VSDD
+# Phase 1c concerns (ambiguous wording, missing edge cases, implicit
+# assumptions, contradictions), and posts the result back as a comment.
+on:
+  issues:
+    types: [opened, edited]
+  workflow_call:
+    secrets:
+      GEMINI_API_KEY:
+        required: true
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  vsdd-issue-review:
+    name: Gemini VSDD Phase 1c review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo (for MEMORY.md context)
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Gemini CLI
+        run: npm install -g @google/gemini-cli
+
+      - name: Run Gemini review with model fallback
+        id: gemini
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -u
+          mkdir -p /tmp/vsdd
+          cat > /tmp/vsdd/prompt.txt <<'PROMPT_EOF'
+          You are Sarcasmotron, the adversarial reviewer described in MEMORY.md
+          (Verified Spec-Driven Development). You are running Phase 1c (Spec
+          Review Gate) on a freshly-filed or freshly-edited GitHub issue.
+
+          Read MEMORY.md in this repo for context on VSDD, then review the
+          issue body below. Look ONLY for these classes of problems:
+
+            - Ambiguous wording that could be interpreted multiple ways
+            - Missing edge cases (null, empty, max size, negative, unicode,
+              concurrent, etc.)
+            - Implicit assumptions that are not stated
+            - Contradictions between different parts of the issue
+            - Properties claimed as "testable only" that should be provable
+            - Purity-boundary violations (logic claimed pure that depends on
+              external state)
+            - Verification-tool mismatches
+
+          Output rules:
+            - Be terse. Bullet points only. No preamble, no "overall this
+              looks good".
+            - Each bullet must be a concrete flaw with a specific quote or
+              location and a proposed fix or clarifying question.
+            - If you genuinely cannot find any of the above classes of
+              problem, output exactly: "No Phase 1c concerns identified."
+            - This review is advisory. Do not pretend it gates anything.
+
+          --- ISSUE TITLE ---
+          PROMPT_EOF
+          printf '%s\n' "$ISSUE_TITLE" >> /tmp/vsdd/prompt.txt
+          printf '\n--- ISSUE BODY ---\n' >> /tmp/vsdd/prompt.txt
+          printf '%s\n' "$ISSUE_BODY" >> /tmp/vsdd/prompt.txt
+
+          run_gemini() {
+            local model="$1"
+            gemini --yolo --model "$model" \
+              --prompt "$(cat /tmp/vsdd/prompt.txt)" \
+              > /tmp/vsdd/review.md 2> /tmp/vsdd/err.log
+          }
+
+          if run_gemini "gemini-3-pro-preview"; then
+            echo "model=gemini-3-pro-preview" >> "$GITHUB_OUTPUT"
+          elif run_gemini "gemini-2.5-pro"; then
+            echo "model=gemini-2.5-pro" >> "$GITHUB_OUTPUT"
+          else
+            echo "model=none" >> "$GITHUB_OUTPUT"
+            echo "Gemini CLI failed on both gemini-3-pro-preview and gemini-2.5-pro." > /tmp/vsdd/review.md
+            echo "stderr tail:" >> /tmp/vsdd/review.md
+            tail -n 40 /tmp/vsdd/err.log >> /tmp/vsdd/review.md || true
+          fi
+
+      - name: Post review as issue comment
+        uses: actions/github-script@v7
+        env:
+          MODEL: ${{ steps.gemini.outputs.model }}
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/vsdd/review.md', 'utf8');
+            const model = process.env.MODEL || 'unknown';
+            const header = `**VSDD Phase 1c — Adversarial Spec Review** _(advisory, model: \`${model}\`)_\n\n`;
+            const footer = `\n\n---\n_This is an automated advisory review per MEMORY.md §II Phase 1c. It does not gate anything._`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: header + body + footer,
+            });

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -22,7 +22,7 @@ jobs:
     name: Gemini VSDD Phase 1c review
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build prompt
         env:
@@ -78,7 +78,7 @@ jobs:
           output-file: /tmp/vsdd/review.md
 
       - name: Post review as issue comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,9 +1,10 @@
 name: VSDD Issue Review (Phase 1c)
 
-# Advisory only — never gates anything.
-# Reads new/edited issues, runs an adversarial Gemini pass looking for VSDD
-# Phase 1c concerns (ambiguous wording, missing edge cases, implicit
-# assumptions, contradictions), and posts the result back as a comment.
+# Advisory adversarial review of new/edited issues by Gemini, per MEMORY.md
+# §II Phase 1c (Spec Review Gate). Posts a comment on the issue with findings.
+# Org membership is enforced inside the gemini composite action — non-members
+# trigger a hard fail of the agent step.
+
 on:
   issues:
     types: [opened, edited]
@@ -17,118 +18,64 @@ permissions:
   contents: read
 
 jobs:
-  membership-gate:
-    name: Org-member gate
-    runs-on: ubuntu-latest
-    outputs:
-      is-member: ${{ steps.check.outputs.is-member }}
-    steps:
-      - id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.event.sender.login || github.actor }}
-        run: |
-          set +e
-          gh api "orgs/sw2m/members/$ACTOR" >/dev/null 2>&1
-          rc=$?
-          set -e
-          if [ "$rc" = "0" ]; then
-            echo "is-member=true" >> "$GITHUB_OUTPUT"
-            echo "✓ $ACTOR is a sw2m org member; agent jobs will run."
-          else
-            echo "is-member=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::$ACTOR is not a sw2m org member; agent job will be skipped."
-          fi
-
   vsdd-issue-review:
     name: Gemini VSDD Phase 1c review
-    needs: [membership-gate]
-    if: needs.membership-gate.outputs.is-member == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo (for MEMORY.md context)
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install Gemini CLI
-        run: npm install -g @google/gemini-cli
-
-      - name: Run Gemini review with model fallback
-        id: gemini
+      - name: Build prompt
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          set -u
           mkdir -p /tmp/vsdd
-          cat > /tmp/vsdd/prompt.txt <<'PROMPT_EOF'
+          cat > /tmp/vsdd/stdin.txt <<'PROMPT_EOF'
           You are Sarcasmotron, the adversarial reviewer described in MEMORY.md
           (Verified Spec-Driven Development). You are running Phase 1c (Spec
           Review Gate) on a freshly-filed or freshly-edited GitHub issue.
 
-          Read MEMORY.md in this repo for context on VSDD, then review the
-          issue body below. Look ONLY for these classes of problems:
-
+          Read MEMORY.md (provided below) for VSDD context, then review the
+          issue body below. Look ONLY for:
             - Ambiguous wording that could be interpreted multiple ways
             - Missing edge cases (null, empty, max size, negative, unicode,
               concurrent, etc.)
             - Implicit assumptions that are not stated
             - Contradictions between different parts of the issue
             - Properties claimed as "testable only" that should be provable
-            - Purity-boundary violations (logic claimed pure that depends on
-              external state)
+            - Purity-boundary violations
             - Verification-tool mismatches
 
           Output rules:
-            - Be terse. Bullet points only. No preamble, no "overall this
-              looks good".
-            - Each bullet must be a concrete flaw with a specific quote or
-              location and a proposed fix or clarifying question.
-            - If you genuinely cannot find any of the above classes of
-              problem, output exactly: "No Phase 1c concerns identified."
+            - Be terse. Bullet points only. No preamble.
+            - Each bullet: a concrete flaw with a specific quote/location and
+              a proposed fix or clarifying question.
+            - If genuinely no concerns: output exactly "No Phase 1c concerns identified."
             - This review is advisory. Do not pretend it gates anything.
 
-          --- ISSUE TITLE ---
+          --- MEMORY.md ---
           PROMPT_EOF
-          printf '%s\n' "$ISSUE_TITLE" >> /tmp/vsdd/prompt.txt
-          printf '\n--- ISSUE BODY ---\n' >> /tmp/vsdd/prompt.txt
-          printf '%s\n' "$ISSUE_BODY" >> /tmp/vsdd/prompt.txt
+          cat MEMORY.md >> /tmp/vsdd/stdin.txt
+          {
+            printf '\n--- ISSUE TITLE ---\n%s\n' "$ISSUE_TITLE"
+            printf '\n--- ISSUE BODY ---\n%s\n' "$ISSUE_BODY"
+          } >> /tmp/vsdd/stdin.txt
 
-          run_gemini() {
-            local model="$1"
-            gemini --yolo --skip-trust --model "$model" \
-              --prompt "$(cat /tmp/vsdd/prompt.txt)" \
-              > /tmp/vsdd/review.md 2> /tmp/vsdd/err.log
-          }
-
-          if run_gemini "gemini-3-pro-preview"; then
-            echo "model=gemini-3-pro-preview" >> "$GITHUB_OUTPUT"
-          elif run_gemini "gemini-2.5-pro"; then
-            echo "model=gemini-2.5-pro" >> "$GITHUB_OUTPUT"
-          else
-            echo "model=none" >> "$GITHUB_OUTPUT"
-            echo "Gemini CLI failed on both gemini-3-pro-preview and gemini-2.5-pro." > /tmp/vsdd/review.md
-            echo "stderr tail:" >> /tmp/vsdd/review.md
-            tail -n 40 /tmp/vsdd/err.log >> /tmp/vsdd/review.md || true
-          fi
+      - name: Run Gemini (composite action; org-member gate enforced inside)
+        uses: ./.github/actions/gemini
+        with:
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          stdin-file: /tmp/vsdd/stdin.txt
+          output-file: /tmp/vsdd/review.md
 
       - name: Post review as issue comment
         uses: actions/github-script@v7
-        env:
-          MODEL: ${{ steps.gemini.outputs.model }}
         with:
           script: |
             const fs = require('fs');
             const body = fs.readFileSync('/tmp/vsdd/review.md', 'utf8');
-            const model = process.env.MODEL || 'unknown';
-            const header = `**VSDD Phase 1c — Adversarial Spec Review** _(advisory, model: \`${model}\`)_\n\n`;
-            const footer = `\n\n---\n_This is an automated advisory review per MEMORY.md §II Phase 1c. It does not gate anything._`;
+            const header = `**VSDD Phase 1c — Adversarial Spec Review** _(advisory)_\n\n`;
+            const footer = `\n\n---\n_Automated advisory review per MEMORY.md §II Phase 1c. Does not gate anything._`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -45,6 +45,11 @@ jobs:
             - Properties claimed as "testable only" that should be provable
             - Purity-boundary violations
             - Verification-tool mismatches
+            - Spec discipline violations (§VII): if this is a tech-spec
+              issue, does it cover exactly one technical problem? Bundled
+              tech specs (multiple problems in one issue body) violate
+              the discrete-tech-spec rule. Goal specs may carry many
+              goals — that's fine, do not flag.
 
           Output rules:
             - Be terse. Bullet points only. No preamble.

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -167,9 +167,15 @@ jobs:
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           output-file: review.md
+          # Same stdin-file pattern as Gemini — Claude has no filesystem
+          # access via the Messages API, so we embed MEMORY.md + pr.diff
+          # directly in the prompt rather than asking Claude to "read" them.
+          stdin-file: gemini-stdin.txt
           prompt: |
             You are an adversarial Phase 3 reviewer (MEMORY.md §II — VSDD).
-            Read `MEMORY.md` and `pr.diff` in the working directory. Apply
+            The canonical VSDD doc and the PR diff under review are
+            EMBEDDED below in the same message — do not look for files; if
+            you cite something, cite from the embedded content. Apply
             these review rules:
               - Code that diverges from the spec it's supposed to satisfy
               - Tautological tests
@@ -201,12 +207,16 @@ jobs:
 
             After the closing `---`, list every concern (blocking and
             nitpicks alike) as terse bullets. Each bullet: a concrete
-            flaw with `file:line` and a proposed fix. Mark blocking
-            concerns explicitly with **(blocking)** at the start of the
-            bullet so the human can scan for them.
+            flaw with `file:line` (cite from the embedded diff) and a
+            proposed fix. Mark blocking concerns explicitly with
+            **(blocking)** at the start of the bullet.
 
             If you genuinely have nothing to say, the body may be a
             single line.
+
+            Critical: if you find yourself citing a file or symbol that
+            isn't actually present in the embedded diff, STOP — that is
+            a hallucination. Only cite what's in the embedded content.
 
       - name: Submit Claude review (APPROVE / REQUEST_CHANGES)
         uses: actions/github-script@v7

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -2,7 +2,9 @@ name: VSDD Pull Request Review (Phase 3)
 
 # Advisory only — never gates the merge. Two adversarial reviewers run in
 # parallel for cognitive diversity (MEMORY.md §V): Gemini and Claude. Each
-# posts its findings as a PR comment. The gating CI is test.yml.
+# posts its findings as a PR comment. Org-membership is enforced inside the
+# composite actions.
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -20,99 +22,88 @@ permissions:
   id-token: write
 
 jobs:
-  gemini-review:
-    name: Gemini adversarial review
+  prep:
+    name: Compute PR diff
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install Gemini CLI
-        run: npm install -g @google/gemini-cli
 
       - name: Compute diff against base
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          mkdir -p /tmp/vsdd
           git fetch origin "$BASE_SHA" --depth=1 || true
-          git diff "$BASE_SHA"..."$HEAD_SHA" > /tmp/vsdd/pr.diff
-          wc -c /tmp/vsdd/pr.diff
-          # Truncate huge diffs so we don't blow the context window.
-          if [ "$(wc -c < /tmp/vsdd/pr.diff)" -gt 200000 ]; then
-            head -c 200000 /tmp/vsdd/pr.diff > /tmp/vsdd/pr.diff.trunc
-            mv /tmp/vsdd/pr.diff.trunc /tmp/vsdd/pr.diff
-            echo "[diff truncated to 200KB]" >> /tmp/vsdd/pr.diff
+          git diff "$BASE_SHA"..."$HEAD_SHA" > pr.diff
+          wc -c pr.diff
+          if [ "$(wc -c < pr.diff)" -gt 200000 ]; then
+            head -c 200000 pr.diff > pr.diff.trunc
+            mv pr.diff.trunc pr.diff
+            echo "[diff truncated to 200KB]" >> pr.diff
           fi
 
-      - name: Run Gemini PR review with model fallback
-        id: gemini
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      - name: Build prompts (gemini + claude)
         run: |
-          set -u
+          cat > gemini-stdin.txt <<'PROMPT_EOF'
+          You are an adversarial Phase 3 reviewer (MEMORY.md §II — Verified
+          Spec-Driven Development). Review the PR diff below against the
+          standards in MEMORY.md (§I–§IX). Look ONLY for:
+            - Code that diverges from the spec it's supposed to satisfy
+            - Tautological tests
+            - Hidden coupling, race conditions, missing cleanup
+            - Multi-word symbols that should be Subject.verb (§IX)
+            - Inconsistent error handling
+            - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
+
+          Output rules: terse bullets only. Each bullet a concrete flaw with
+          file:line and a proposed fix. If genuinely none: output exactly
+          "No Phase 3 concerns identified." This review is advisory.
+
+          --- MEMORY.md ---
+          PROMPT_EOF
+          cat MEMORY.md >> gemini-stdin.txt
           {
-            echo "You are Sarcasmotron, the adversarial reviewer described in"
-            echo "MEMORY.md. You are running Phase 3 (Adversarial Refinement)"
-            echo "on the diff below. Use MEMORY.md in this repo as the standard."
-            echo ""
-            echo "Look for: spec fidelity gaps, weak/tautological tests, code"
-            echo "quality issues (placeholders, generic error handling, hidden"
-            echo "coupling, race conditions), security surface, spec gaps the"
-            echo "implementation reveals, multi-word symbol smells (§IX),"
-            echo "regression-set/4-Result-Rule violations (§VIII), and spec"
-            echo "discipline violations (§VII)."
-            echo ""
-            echo "Output rules: bullet points only, each one a concrete flaw"
-            echo "with a file:line reference and a proposed fix or question."
-            echo "If genuinely nothing, output exactly: 'No Phase 3 concerns"
-            echo "identified.' This review is advisory."
-            echo ""
-            echo "--- MEMORY.md ---"
-            cat MEMORY.md
-            echo ""
-            echo "--- DIFF ---"
-            cat /tmp/vsdd/pr.diff
-          } > /tmp/vsdd/prompt.txt
+            printf '\n--- PR DIFF ---\n'
+            cat pr.diff
+          } >> gemini-stdin.txt
 
-          run_gemini() {
-            local model="$1"
-            gemini --yolo --skip-trust --model "$model" \
-              --prompt "$(cat /tmp/vsdd/prompt.txt)" \
-              > /tmp/vsdd/review.md 2> /tmp/vsdd/err.log
-          }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-context
+          path: |
+            gemini-stdin.txt
+            pr.diff
+            MEMORY.md
 
-          if run_gemini "gemini-3-pro-preview"; then
-            echo "model=gemini-3-pro-preview" >> "$GITHUB_OUTPUT"
-          elif run_gemini "gemini-2.5-pro"; then
-            echo "model=gemini-2.5-pro" >> "$GITHUB_OUTPUT"
-          else
-            echo "model=none" >> "$GITHUB_OUTPUT"
-            echo "Gemini CLI failed on both gemini-3-pro-preview and gemini-2.5-pro." > /tmp/vsdd/review.md
-            echo "stderr tail:" >> /tmp/vsdd/review.md
-            tail -n 40 /tmp/vsdd/err.log >> /tmp/vsdd/review.md || true
-          fi
+  gemini-review:
+    name: Gemini adversarial review
+    needs: [prep]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-context
+          path: ./
 
-      - name: Post Gemini review as PR comment
+      - name: Run Gemini (composite; org-member gate inside)
+        uses: ./.github/actions/gemini
+        with:
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          stdin-file: gemini-stdin.txt
+          output-file: review.md
+
+      - name: Post Gemini comment
         uses: actions/github-script@v7
-        env:
-          MODEL: ${{ steps.gemini.outputs.model }}
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('/tmp/vsdd/review.md', 'utf8');
-            const model = process.env.MODEL || 'unknown';
-            const header = `**VSDD Phase 3 — Gemini Adversarial Review** _(advisory, model: \`${model}\`)_\n\n`;
-            const footer = `\n\n---\n_Advisory review per MEMORY.md §II Phase 3. Does not gate the merge._`;
+            const body = fs.readFileSync('review.md', 'utf8');
+            const header = `**VSDD Phase 3 — Gemini adversarial review** _(advisory)_\n\n`;
+            const footer = `\n\n---\n_Automated advisory review per MEMORY.md §II Phase 3. Does not gate the merge._`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -122,37 +113,46 @@ jobs:
 
   claude-review:
     name: Claude adversarial review
+    needs: [prep]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          name: pr-context
+          path: ./
 
-      - name: Run Claude review (anthropics/claude-code-action)
-        uses: anthropics/claude-code-action@v1
+      - name: Run Claude (composite; org-member gate inside)
+        uses: ./.github/actions/claude
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          output-file: review.md
           prompt: |
-            You are the second adversarial reviewer in MEMORY.md's Phase 3
-            (Adversarial Refinement). Your role here mirrors Sarcasmotron, but
-            you are Claude — the cognitive-diversity counterpart per §V.
+            You are an adversarial Phase 3 reviewer (MEMORY.md §II — VSDD).
+            Read `MEMORY.md` and `pr.diff` in the working directory. Apply
+            these review rules:
+              - Code that diverges from the spec it's supposed to satisfy
+              - Tautological tests
+              - Hidden coupling, race conditions, missing cleanup
+              - Multi-word symbols that should be `Subject.verb` (§IX)
+              - Inconsistent error handling
+              - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
 
-            Read MEMORY.md in this repo as the standard. Review this pull
-            request's diff against it. Look for: spec fidelity, weak or
-            tautological tests, code quality (placeholders, generic error
-            handling, hidden coupling, race conditions), security surface,
-            spec gaps the implementation reveals, multi-word symbol smells
-            (§IX), regression-set / 4-Result-Rule violations (§VIII), and
-            spec discipline violations (§VII — goal vs tech specs, one
-            problem per tech spec).
+            Output rules: terse bullets only. Each bullet a concrete flaw
+            with `file:line` and a proposed fix. If none: write exactly
+            "No Phase 3 concerns identified.". This review is advisory.
 
-            Output rules: bullet points only. Every bullet is a concrete flaw
-            with a specific file:line reference and a proposed fix or
-            question. No preamble. If you genuinely cannot find anything,
-            output exactly: "No Phase 3 concerns identified."
-
-            This review is advisory. It does not gate the merge.
-          claude_args: |
-            --max-turns 8
+      - name: Post Claude comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('review.md', 'utf8');
+            const header = `**VSDD Phase 3 — Claude adversarial review** _(advisory)_\n\n`;
+            const footer = `\n\n---\n_Automated advisory review per MEMORY.md §II Phase 3. Does not gate the merge._`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: header + body + footer,
+            });

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -86,7 +86,7 @@ jobs:
 
           run_gemini() {
             local model="$1"
-            gemini --yolo --model "$model" \
+            gemini --yolo --skip-trust --model "$model" \
               --prompt "$(cat /tmp/vsdd/prompt.txt)" \
               > /tmp/vsdd/review.md 2> /tmp/vsdd/err.log
           }

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -42,11 +42,15 @@ jobs:
         run: |
           git fetch origin "$BASE_SHA" --depth=1 || true
           git diff "$BASE_SHA"..."$HEAD_SHA" > pr.diff
-          wc -c pr.diff
-          if [ "$(wc -c < pr.diff)" -gt 200000 ]; then
-            head -c 200000 pr.diff > pr.diff.trunc
+          wc -l pr.diff
+          # Truncate by LINES, not bytes — byte truncation can slice mid-line,
+          # mid-hunk, or mid-multibyte-character, producing malformed diffs
+          # that confuse model parsers.
+          if [ "$(wc -l < pr.diff)" -gt 5000 ]; then
+            head -n 5000 pr.diff > pr.diff.trunc
             mv pr.diff.trunc pr.diff
-            echo "[diff truncated to 200KB]" >> pr.diff
+            echo "" >> pr.diff
+            echo "[diff truncated to 5000 lines]" >> pr.diff
           fi
 
       - name: Build prompts (gemini + claude)
@@ -112,6 +116,10 @@ jobs:
   gemini-review:
     name: Gemini adversarial review
     needs: [prep]
+    # Skip cleanly when GEMINI_API_KEY isn't available (e.g. fork PR without
+    # secret access). Without this guard the composite action would fail
+    # noisily, violating the 'advisory only — never gates' contract.
+    if: ${{ secrets.GEMINI_API_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -132,27 +140,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const path = require('path');
+            const { extractVerdict } = require(path.resolve('.github/scripts/extract-verdict.js'));
             const raw = fs.readFileSync('review.md', 'utf8');
-            // Forgiving verdict extractor (same as ci-meta consensus parser):
-            //   1. Strict frontmatter at the top: ---\nverdict: ...\n---
-            //   2. An embedded frontmatter block elsewhere
-            //   3. A bare 'verdict: pass|fail' line anywhere
-            // Falls through to 'unparseable' which fails the workflow.
-            function extractVerdict(text) {
-              const m1 = text.match(/^\s*---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
-              if (m1) {
-                const fm = m1[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
-                if (fm) return { verdict: fm[1].toLowerCase(), body: m1[2].trim() };
-              }
-              const m2 = text.match(/\n---\s*\n(verdict\s*:\s*(?:pass|fail)[\s\S]*?)\n---\s*\n/);
-              if (m2) {
-                const fm = m2[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
-                if (fm) return { verdict: fm[1].toLowerCase(), body: text };
-              }
-              const m3 = text.match(/^\s*\**\s*verdict\s*\**\s*[:=]\s*\**\s*(pass|fail)\b/im);
-              if (m3) return { verdict: m3[1].toLowerCase(), body: text };
-              return { verdict: null, body: text };
-            }
             const { verdict, body } = extractVerdict(raw);
             if (verdict !== 'pass' && verdict !== 'fail') {
               core.setFailed('Gemini output had no extractable verdict (no frontmatter, no fallback match). Failing the workflow; raw output is preserved in the review body for human triage.');
@@ -171,6 +161,9 @@ jobs:
   claude-review:
     name: Claude adversarial review
     needs: [prep]
+    # Same guard as gemini-review — skip cleanly when ANTHROPIC_API_KEY isn't
+    # available rather than fail noisily.
+    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -260,23 +253,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const path = require('path');
+            const { extractVerdict } = require(path.resolve('.github/scripts/extract-verdict.js'));
             const raw = fs.readFileSync('review.md', 'utf8');
-            // Same forgiving verdict extractor as the Gemini job above.
-            function extractVerdict(text) {
-              const m1 = text.match(/^\s*---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
-              if (m1) {
-                const fm = m1[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
-                if (fm) return { verdict: fm[1].toLowerCase(), body: m1[2].trim() };
-              }
-              const m2 = text.match(/\n---\s*\n(verdict\s*:\s*(?:pass|fail)[\s\S]*?)\n---\s*\n/);
-              if (m2) {
-                const fm = m2[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
-                if (fm) return { verdict: fm[1].toLowerCase(), body: text };
-              }
-              const m3 = text.match(/^\s*\**\s*verdict\s*\**\s*[:=]\s*\**\s*(pass|fail)\b/im);
-              if (m3) return { verdict: m3[1].toLowerCase(), body: text };
-              return { verdict: null, body: text };
-            }
             const { verdict, body } = extractVerdict(raw);
             if (verdict !== 'pass' && verdict !== 'fail') {
               core.setFailed('Claude output had no extractable verdict (no frontmatter, no fallback match). Failing the workflow; raw output is preserved in the review body for human triage.');

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -10,7 +10,7 @@ on:
     secrets:
       GEMINI_API_KEY:
         required: false
-      CLAUDE_CODE_OAUTH_TOKEN:
+      ANTHROPIC_API_KEY:
         required: false
 
 permissions:
@@ -133,7 +133,7 @@ jobs:
       - name: Run Claude review (anthropics/claude-code-action)
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             You are the second adversarial reviewer in MEMORY.md's Phase 3
             (Adversarial Refinement). Your role here mirrors Sarcasmotron, but

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -58,9 +58,36 @@ jobs:
             - Inconsistent error handling
             - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
 
-          Output rules: terse bullets only. Each bullet a concrete flaw with
-          file:line and a proposed fix. If genuinely none: output exactly
-          "No Phase 3 concerns identified." This review is advisory.
+          # OUTPUT FORMAT (strict)
+
+          Begin your response with YAML frontmatter, exactly this shape:
+
+          ---
+          verdict: pass | fail
+          ---
+
+          The verdict answers "should this PR be approved?", **not** "are
+          there zero concerns?". A `pass` with listed nitpicks is correct
+          and expected — concerns can exist without blocking.
+
+          - `verdict: pass` ⇔ concerns are nits/style/nice-to-have. The PR
+            is acceptable as-is; the human can address the nits or dismiss
+            them. Translates to APPROVE.
+          - `verdict: fail` ⇔ at least one concern is genuinely blocking
+            (correctness, security, broken contract, spec violation that
+            invalidates the change). Translates to REQUEST_CHANGES.
+
+          The frontmatter MUST be the first thing in your output (no leading
+          whitespace, no preamble).
+
+          After the closing `---`, list every concern (blocking and
+          nitpicks alike) as terse bullets. Each bullet: a concrete flaw
+          with `file:line` and a proposed fix. Mark blocking concerns
+          explicitly with **(blocking)** at the start of the bullet so the
+          human reading can scan for them.
+
+          If you genuinely have nothing to say, the body may be a single
+          line.
 
           --- MEMORY.md ---
           PROMPT_EOF
@@ -96,18 +123,31 @@ jobs:
           stdin-file: gemini-stdin.txt
           output-file: review.md
 
-      - name: Post Gemini comment
+      - name: Submit Gemini review (APPROVE / REQUEST_CHANGES)
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('review.md', 'utf8');
-            const header = `**VSDD Phase 3 — Gemini adversarial review** _(advisory)_\n\n`;
-            const footer = `\n\n---\n_Automated advisory review per MEMORY.md §II Phase 3. Does not gate the merge._`;
-            await github.rest.issues.createComment({
+            const raw = fs.readFileSync('review.md', 'utf8');
+            // Parse YAML frontmatter at the top: ---\nverdict: pass|fail\n---\n
+            const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+            let verdict = null, body = raw;
+            if (m) {
+              const fmMatch = m[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+              verdict = fmMatch ? fmMatch[1].toLowerCase() : null;
+              body = m[2].trim();
+            }
+            if (verdict !== 'pass' && verdict !== 'fail') {
+              core.setFailed(`Gemini did not produce a parseable verdict frontmatter (got: ${verdict ?? 'none'}). Raw output preserved as the review body for human triage; failing the workflow.`);
+            }
+            const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
+            const header = `**VSDD Phase 3 — Gemini adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
+            const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
+            await github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              pull_number: context.issue.number,
+              event,
               body: header + body + footer,
             });
 
@@ -138,21 +178,59 @@ jobs:
               - Inconsistent error handling
               - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
 
-            Output rules: terse bullets only. Each bullet a concrete flaw
-            with `file:line` and a proposed fix. If none: write exactly
-            "No Phase 3 concerns identified.". This review is advisory.
+            # OUTPUT FORMAT (strict)
 
-      - name: Post Claude comment
+            Begin your written output with YAML frontmatter, exactly:
+
+            ---
+            verdict: pass | fail
+            ---
+
+            The verdict answers "should this PR be approved?", not "are
+            there zero concerns?". A `pass` with listed nitpicks is
+            correct — concerns can exist without blocking.
+
+            - `verdict: pass` ⇔ concerns are nits/style/nice-to-have.
+              Translates to APPROVE.
+            - `verdict: fail` ⇔ at least one concern is genuinely blocking
+              (correctness, security, broken contract, spec violation).
+              Translates to REQUEST_CHANGES.
+
+            The frontmatter MUST be the first thing in the file (no
+            leading whitespace, no preamble).
+
+            After the closing `---`, list every concern (blocking and
+            nitpicks alike) as terse bullets. Each bullet: a concrete
+            flaw with `file:line` and a proposed fix. Mark blocking
+            concerns explicitly with **(blocking)** at the start of the
+            bullet so the human can scan for them.
+
+            If you genuinely have nothing to say, the body may be a
+            single line.
+
+      - name: Submit Claude review (APPROVE / REQUEST_CHANGES)
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('review.md', 'utf8');
-            const header = `**VSDD Phase 3 — Claude adversarial review** _(advisory)_\n\n`;
-            const footer = `\n\n---\n_Automated advisory review per MEMORY.md §II Phase 3. Does not gate the merge._`;
-            await github.rest.issues.createComment({
+            const raw = fs.readFileSync('review.md', 'utf8');
+            const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+            let verdict = null, body = raw;
+            if (m) {
+              const fmMatch = m[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+              verdict = fmMatch ? fmMatch[1].toLowerCase() : null;
+              body = m[2].trim();
+            }
+            if (verdict !== 'pass' && verdict !== 'fail') {
+              core.setFailed(`Claude did not produce a parseable verdict frontmatter (got: ${verdict ?? 'none'}).`);
+            }
+            const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
+            const header = `**VSDD Phase 3 — Claude adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
+            const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
+            await github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              pull_number: context.issue.number,
+              event,
               body: header + body + footer,
             });

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -129,16 +129,29 @@ jobs:
           script: |
             const fs = require('fs');
             const raw = fs.readFileSync('review.md', 'utf8');
-            // Parse YAML frontmatter at the top: ---\nverdict: pass|fail\n---\n
-            const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
-            let verdict = null, body = raw;
-            if (m) {
-              const fmMatch = m[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
-              verdict = fmMatch ? fmMatch[1].toLowerCase() : null;
-              body = m[2].trim();
+            // Forgiving verdict extractor (same as ci-meta consensus parser):
+            //   1. Strict frontmatter at the top: ---\nverdict: ...\n---
+            //   2. An embedded frontmatter block elsewhere
+            //   3. A bare 'verdict: pass|fail' line anywhere
+            // Falls through to 'unparseable' which fails the workflow.
+            function extractVerdict(text) {
+              const m1 = text.match(/^\s*---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
+              if (m1) {
+                const fm = m1[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+                if (fm) return { verdict: fm[1].toLowerCase(), body: m1[2].trim() };
+              }
+              const m2 = text.match(/\n---\s*\n(verdict\s*:\s*(?:pass|fail)[\s\S]*?)\n---\s*\n/);
+              if (m2) {
+                const fm = m2[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+                if (fm) return { verdict: fm[1].toLowerCase(), body: text };
+              }
+              const m3 = text.match(/^\s*\**\s*verdict\s*\**\s*[:=]\s*\**\s*(pass|fail)\b/im);
+              if (m3) return { verdict: m3[1].toLowerCase(), body: text };
+              return { verdict: null, body: text };
             }
+            const { verdict, body } = extractVerdict(raw);
             if (verdict !== 'pass' && verdict !== 'fail') {
-              core.setFailed(`Gemini did not produce a parseable verdict frontmatter (got: ${verdict ?? 'none'}). Raw output preserved as the review body for human triage; failing the workflow.`);
+              core.setFailed('Gemini output had no extractable verdict (no frontmatter, no fallback match). Failing the workflow; raw output is preserved in the review body for human triage.');
             }
             const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
             const header = `**VSDD Phase 3 — Gemini adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
@@ -172,6 +185,26 @@ jobs:
           # directly in the prompt rather than asking Claude to "read" them.
           stdin-file: gemini-stdin.txt
           prompt: |
+            # CRITICAL OUTPUT FORMAT (read this FIRST)
+
+            Your response MUST start, on the very first line, with exactly `---` (no leading whitespace, no preamble), then `verdict: pass` or `verdict: fail`, then `---`, then your bullet list.
+
+            Acceptable response example:
+
+            ```
+            ---
+            verdict: fail
+            ---
+
+            - **(blocking)** path/to/file.ts:42 — Bug description. Fix: …
+            - path/to/other.ts:10 — Nitpick. Fix: …
+            ```
+
+            If you do not produce frontmatter as your first output, the workflow
+            will fail and your review will be discarded. Non-negotiable.
+
+            # TASK
+
             You are an adversarial Phase 3 reviewer (MEMORY.md §II — VSDD).
             The canonical VSDD doc and the PR diff under review are
             EMBEDDED below in the same message — do not look for files; if
@@ -224,15 +257,25 @@ jobs:
           script: |
             const fs = require('fs');
             const raw = fs.readFileSync('review.md', 'utf8');
-            const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
-            let verdict = null, body = raw;
-            if (m) {
-              const fmMatch = m[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
-              verdict = fmMatch ? fmMatch[1].toLowerCase() : null;
-              body = m[2].trim();
+            // Same forgiving verdict extractor as the Gemini job above.
+            function extractVerdict(text) {
+              const m1 = text.match(/^\s*---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
+              if (m1) {
+                const fm = m1[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+                if (fm) return { verdict: fm[1].toLowerCase(), body: m1[2].trim() };
+              }
+              const m2 = text.match(/\n---\s*\n(verdict\s*:\s*(?:pass|fail)[\s\S]*?)\n---\s*\n/);
+              if (m2) {
+                const fm = m2[1].match(/^\s*verdict\s*:\s*(pass|fail)\s*$/im);
+                if (fm) return { verdict: fm[1].toLowerCase(), body: text };
+              }
+              const m3 = text.match(/^\s*\**\s*verdict\s*\**\s*[:=]\s*\**\s*(pass|fail)\b/im);
+              if (m3) return { verdict: m3[1].toLowerCase(), body: text };
+              return { verdict: null, body: text };
             }
+            const { verdict, body } = extractVerdict(raw);
             if (verdict !== 'pass' && verdict !== 'fail') {
-              core.setFailed(`Claude did not produce a parseable verdict frontmatter (got: ${verdict ?? 'none'}).`);
+              core.setFailed('Claude output had no extractable verdict (no frontmatter, no fallback match). Failing the workflow; raw output is preserved in the review body for human triage.');
             }
             const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
             const header = `**VSDD Phase 3 — Claude adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -101,7 +101,7 @@ jobs:
             cat pr.diff
           } >> gemini-stdin.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: pr-context
           path: |
@@ -114,8 +114,8 @@ jobs:
     needs: [prep]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: pr-context
           path: ./
@@ -128,7 +128,7 @@ jobs:
           output-file: review.md
 
       - name: Submit Gemini review (APPROVE / REQUEST_CHANGES)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -173,8 +173,8 @@ jobs:
     needs: [prep]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: pr-context
           path: ./
@@ -256,7 +256,7 @@ jobs:
             a hallucination. Only cite what's in the embedded content.
 
       - name: Submit Claude review (APPROVE / REQUEST_CHANGES)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -1,0 +1,158 @@
+name: VSDD Pull Request Review (Phase 3)
+
+# Advisory only — never gates the merge. Two adversarial reviewers run in
+# parallel for cognitive diversity (MEMORY.md §V): Gemini and Claude. Each
+# posts its findings as a PR comment. The gating CI is test.yml.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_call:
+    secrets:
+      GEMINI_API_KEY:
+        required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  gemini-review:
+    name: Gemini adversarial review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Gemini CLI
+        run: npm install -g @google/gemini-cli
+
+      - name: Compute diff against base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p /tmp/vsdd
+          git fetch origin "$BASE_SHA" --depth=1 || true
+          git diff "$BASE_SHA"..."$HEAD_SHA" > /tmp/vsdd/pr.diff
+          wc -c /tmp/vsdd/pr.diff
+          # Truncate huge diffs so we don't blow the context window.
+          if [ "$(wc -c < /tmp/vsdd/pr.diff)" -gt 200000 ]; then
+            head -c 200000 /tmp/vsdd/pr.diff > /tmp/vsdd/pr.diff.trunc
+            mv /tmp/vsdd/pr.diff.trunc /tmp/vsdd/pr.diff
+            echo "[diff truncated to 200KB]" >> /tmp/vsdd/pr.diff
+          fi
+
+      - name: Run Gemini PR review with model fallback
+        id: gemini
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          set -u
+          {
+            echo "You are Sarcasmotron, the adversarial reviewer described in"
+            echo "MEMORY.md. You are running Phase 3 (Adversarial Refinement)"
+            echo "on the diff below. Use MEMORY.md in this repo as the standard."
+            echo ""
+            echo "Look for: spec fidelity gaps, weak/tautological tests, code"
+            echo "quality issues (placeholders, generic error handling, hidden"
+            echo "coupling, race conditions), security surface, spec gaps the"
+            echo "implementation reveals, multi-word symbol smells (§IX),"
+            echo "regression-set/4-Result-Rule violations (§VIII), and spec"
+            echo "discipline violations (§VII)."
+            echo ""
+            echo "Output rules: bullet points only, each one a concrete flaw"
+            echo "with a file:line reference and a proposed fix or question."
+            echo "If genuinely nothing, output exactly: 'No Phase 3 concerns"
+            echo "identified.' This review is advisory."
+            echo ""
+            echo "--- MEMORY.md ---"
+            cat MEMORY.md
+            echo ""
+            echo "--- DIFF ---"
+            cat /tmp/vsdd/pr.diff
+          } > /tmp/vsdd/prompt.txt
+
+          run_gemini() {
+            local model="$1"
+            gemini --yolo --model "$model" \
+              --prompt "$(cat /tmp/vsdd/prompt.txt)" \
+              > /tmp/vsdd/review.md 2> /tmp/vsdd/err.log
+          }
+
+          if run_gemini "gemini-3-pro-preview"; then
+            echo "model=gemini-3-pro-preview" >> "$GITHUB_OUTPUT"
+          elif run_gemini "gemini-2.5-pro"; then
+            echo "model=gemini-2.5-pro" >> "$GITHUB_OUTPUT"
+          else
+            echo "model=none" >> "$GITHUB_OUTPUT"
+            echo "Gemini CLI failed on both gemini-3-pro-preview and gemini-2.5-pro." > /tmp/vsdd/review.md
+            echo "stderr tail:" >> /tmp/vsdd/review.md
+            tail -n 40 /tmp/vsdd/err.log >> /tmp/vsdd/review.md || true
+          fi
+
+      - name: Post Gemini review as PR comment
+        uses: actions/github-script@v7
+        env:
+          MODEL: ${{ steps.gemini.outputs.model }}
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/vsdd/review.md', 'utf8');
+            const model = process.env.MODEL || 'unknown';
+            const header = `**VSDD Phase 3 — Gemini Adversarial Review** _(advisory, model: \`${model}\`)_\n\n`;
+            const footer = `\n\n---\n_Advisory review per MEMORY.md §II Phase 3. Does not gate the merge._`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: header + body + footer,
+            });
+
+  claude-review:
+    name: Claude adversarial review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run Claude review (anthropics/claude-code-action)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are the second adversarial reviewer in MEMORY.md's Phase 3
+            (Adversarial Refinement). Your role here mirrors Sarcasmotron, but
+            you are Claude — the cognitive-diversity counterpart per §V.
+
+            Read MEMORY.md in this repo as the standard. Review this pull
+            request's diff against it. Look for: spec fidelity, weak or
+            tautological tests, code quality (placeholders, generic error
+            handling, hidden coupling, race conditions), security surface,
+            spec gaps the implementation reveals, multi-word symbol smells
+            (§IX), regression-set / 4-Result-Rule violations (§VIII), and
+            spec discipline violations (§VII — goal vs tech specs, one
+            problem per tech spec).
+
+            Output rules: bullet points only. Every bullet is a concrete flaw
+            with a specific file:line reference and a proposed fix or
+            question. No preamble. If you genuinely cannot find anything,
+            output exactly: "No Phase 3 concerns identified."
+
+            This review is advisory. It does not gate the merge.
+          claude_args: |
+            --max-turns 8

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -7,7 +7,10 @@ name: VSDD Pull Request Review (Phase 3)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `ready_for_review` is added so jobs run when a draft is promoted to
+    # ready. Drafts themselves are skipped at job level via the
+    # `if: github.event.pull_request.draft != true` guard below.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_call:
     secrets:
       GEMINI_API_KEY:
@@ -24,6 +27,7 @@ permissions:
 jobs:
   prep:
     name: Compute PR diff
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: VSDD Testing CI
+
+# Gating workflow — branch protection on main requires this to pass.
+# Markdown lint, link check, and a structural sanity check on MEMORY.md.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: "**/*.md"
+
+  linkcheck:
+    name: External link check (lychee)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-concurrency 4
+            --exclude json-schema.org
+            --exclude spec.openapis.org
+            MEMORY.md
+          fail: true
+
+  structural-sanity:
+    name: MEMORY.md structural sanity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assert all 9 numbered sections are present
+        run: bash .github/scripts/check-memory-structure.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,21 @@ on:
   push:
     branches: [main]
   pull_request:
+    # `ready_for_review` so jobs run when a draft is promoted. Drafts are
+    # skipped at job level via the `if: ... draft != true` guard below.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_call: {}
 
 permissions:
   contents: read
 
+# Skip every job on draft PRs — applies uniformly via this anchor that each
+# job references. Push and workflow_call events are unaffected because
+# `github.event.pull_request.draft` is undefined there (≠ true).
 jobs:
   markdownlint:
     name: Markdown lint
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,6 +33,7 @@ jobs:
 
   linkcheck:
     name: External link check (lychee)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,6 +52,7 @@ jobs:
 
   structural-sanity:
     name: MEMORY.md structural sanity
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@v16
+        uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           globs: "**/*.md"
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run lychee
         uses: lycheeverse/lychee-action@v2
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Assert all 9 numbered sections are present
         run: bash .github/scripts/check-memory-structure.sh

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD036": false,
+  "MD041": false,
+  "MD024": { "siblings_only": true },
+  "MD033": { "allowed_elements": ["br"] }
+}

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -235,9 +235,11 @@ For rapid prototyping or throwaway scripts, use the parts that make sense — TD
 
 The reason VSDD splits specs from implementation is so each unit of work can be **discrete and focused on one technical problem**. That discipline only holds if the spec itself respects a second split: **goal specs** vs **tech specs**.
 
-- **Goal spec.** Captures *what must be true when this work is done.* Carries breadth — many goals in one document is fine. The point of a goal spec is to enumerate the surface area, not to design a solution. Examples: a feature checklist drawn from an external standard, a coverage matrix, a list of acceptance conditions. A goal spec with 300 line items is not a smell — it's working as intended.
+- **Goal spec.** Captures *what must be true when this work is done.* Carries **breadth** — many goals in one document is fine; a goal spec with 300 line items is not a smell. The point is to enumerate the surface area, not to design a solution. **Goal specs must NOT include technical content** (implementation details, API shapes, code, algorithms): the *how* belongs in tech specs. If you find yourself writing pseudocode or describing a solution inside a goal spec, stop — that material is a tech spec being written in the wrong place. Examples of valid goal-spec content: feature checklist drawn from an external standard, coverage matrix, acceptance criteria, observed behavior of a reference implementation.
 
-- **Tech spec.** Captures *how exactly one technical problem will be solved.* One problem per tech spec. No grouping, no bundling, no section-level "tech spec" that covers a dozen goals. The point of a tech spec is depth and focus on a single problem.
+- **Tech spec.** Captures *how exactly one technical problem will be solved.* Carries **depth** — one problem per tech spec. No grouping, no bundling, no section-level "tech spec" that covers a dozen goals. The point is focus on a single problem so design choices can be reviewed in isolation.
+
+The two rules are symmetric. Goal specs may have many entries but no technicals; tech specs may have many technicals but only for one problem. Mixing the two — a goal spec with embedded design, or a tech spec covering several problems — defeats the purpose of separating them in the first place.
 
 When a goal spec contains N goals, that becomes **N tech specs** — one per goal — not fewer-by-grouping. The instinct to "save clutter" by combining tech specs defeats the entire reason to separate them from goal specs in the first place.
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -295,6 +295,27 @@ Multi-word symbols are an indicator of poorly architected code, because they can
 
 ---
 
+## CI/CD
+
+This repo's `.github/workflows/` enforces VSDD on itself. Three workflows, mirroring the pipeline:
+
+- **`issues.yml`** — fires on `issues: [opened, edited]`. Runs Gemini as Sarcasmotron (Phase 1c, Spec Review Gate) against the issue body and posts the critique as a comment. **Advisory only — never gates.**
+- **`pulls.yml`** — fires on `pull_request: [opened, synchronize, reopened]`. Runs *two* adversarial reviewers in parallel — Gemini and Claude — against the diff with `MEMORY.md` as the standard (Phase 3, Adversarial Refinement). Two cognitive sources per §V. Each posts a PR comment. **Advisory only — never gates.**
+- **`test.yml`** — fires on `push` to `main` and on `pull_request`. Markdown lint, external link check (lychee), and a structural sanity check that all nine Roman-numeral sections of `MEMORY.md` are present. **This is the gating workflow** required by the branch-protection rule on `main`.
+
+Each workflow also exposes a `workflow_call:` trigger so other `sw2m` repos can reuse them:
+
+```yaml
+jobs:
+  vsdd-pulls:
+    uses: sw2m/philosophies/.github/workflows/pulls.yml@main
+    secrets: inherit
+```
+
+Required repo secrets: `GEMINI_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`.
+
+---
+
 ## Sources
 
 - Sections I–VI: [VSDD canonical gist](https://gist.github.com/dollspace-gay/d8d3bc3ecf4188df049d7a4726bb2a00) by [@dollspace-gay](https://github.com/dollspace-gay), used verbatim.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -292,13 +292,14 @@ Multi-word symbols are an indicator of poorly architected code, because they can
 
 ## CI/CD
 
-This repo's `.github/workflows/` enforces VSDD on itself. Three workflows, mirroring the pipeline:
+This repo's `.github/workflows/` enforces VSDD on itself. Four workflows, mirroring the pipeline:
 
 - **`issues.yml`** — fires on `issues: [opened, edited]`. Runs Gemini as Sarcasmotron (Phase 1c, Spec Review Gate) against the issue body and posts the critique as a comment. **Advisory only — never gates.**
 - **`pulls.yml`** — fires on `pull_request: [opened, synchronize, reopened]`. Runs *two* adversarial reviewers in parallel — Gemini and Claude — against the diff with `MEMORY.md` as the standard (Phase 3, Adversarial Refinement). Two cognitive sources per §V. Each posts a PR comment. **Advisory only — never gates.**
-- **`test.yml`** — fires on `push` to `main` and on `pull_request`. Markdown lint, external link check (lychee), and a structural sanity check that all nine Roman-numeral sections of `MEMORY.md` are present. **This is the gating workflow** required by the branch-protection rule on `main`.
+- **`test.yml`** — fires on `push` to `main` and on `pull_request`. Markdown lint, external link check (lychee), and a structural sanity check that all nine Roman-numeral sections of `MEMORY.md` are present. **Gating** — required by the branch-protection rule on `main`.
+- **`ci-meta.yml`** — fires on `pull_request` when `.github/workflows/**` or `MEMORY.md` change. Runs Gemini *and* Claude in parallel against the proposed CI workflows; both must reach consensus that the CI correctly enforces VSDD. Disagreement opens a tracked issue per gap (deduped by title) and fails the consensus check. **Surfaces red on disagreement but is not in the protection rule's required-checks list** — gaps are tracked as issues for follow-up; the user decides whether to address each before merge.
 
-Each workflow also exposes a `workflow_call:` trigger so other `sw2m` repos can reuse them:
+Each workflow exposes a `workflow_call:` trigger so other `sw2m` repos can reuse them:
 
 ```yaml
 jobs:
@@ -307,7 +308,7 @@ jobs:
     secrets: inherit
 ```
 
-Required repo secrets: `GEMINI_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`.
+Required repo secrets: `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`.
 
 ---
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -173,7 +173,7 @@ VSDD inherits VDD's **hallucination-based termination**, extended across all thr
 
 One of VSDD's defining properties is **full traceability**. Every artifact links back:
 
-```
+```text
 Spec Requirement → Verification Property → Chainlink Bead → Test Case → Implementation → Adversarial Review → Formal Proof
 ```
 
@@ -189,15 +189,15 @@ At any point, you can ask: *"Why does this line of code exist?"* and trace it al
 
 3. **Red Before Green:** No implementation code is written until a failing test demands it. AI models are explicitly constrained to follow TDD discipline — no "let me just write the whole thing and add tests after."
 
-3. **Anti-Slop Bias:** The first "correct" version is assumed to contain hidden debt. Trust is earned through adversarial survival, not initial appearance.
+4. **Anti-Slop Bias:** The first "correct" version is assumed to contain hidden debt. Trust is earned through adversarial survival, not initial appearance.
 
-4. **Forced Negativity:** Adversarial pressure bypasses the politeness filters of standard LLM interactions. The Adversary doesn't care about your feelings — it cares about your invariants.
+5. **Forced Negativity:** Adversarial pressure bypasses the politeness filters of standard LLM interactions. The Adversary doesn't care about your feelings — it cares about your invariants.
 
-5. **Linear Accountability:** Chainlink beads ensure every spec item, test, and line of code has a corresponding tracked unit of work. Nothing slips through the cracks.
+6. **Linear Accountability:** Chainlink beads ensure every spec item, test, and line of code has a corresponding tracked unit of work. Nothing slips through the cracks.
 
-6. **Entropy Resistance:** Context resets on every adversarial pass prevent the natural degradation of long-running AI conversations.
+7. **Entropy Resistance:** Context resets on every adversarial pass prevent the natural degradation of long-running AI conversations.
 
-7. **Four-Dimensional Convergence:** The system isn't done until specs, tests, implementation, *and* formal proofs have all independently survived adversarial review.
+8. **Four-Dimensional Convergence:** The system isn't done until specs, tests, implementation, *and* formal proofs have all independently survived adversarial review.
 
 ---
 
@@ -260,8 +260,6 @@ When a goal spec contains N goals, that becomes **N tech specs** — one per goa
 
 Both Red Gate runs (new = fail, regression = pass) are **required before writing any implementation code**. Both Green Gate runs (new = pass, regression = pass) are **required to exit Phase 2**. If regression tests fail at any point, the implementation has introduced a regression and must be fixed before proceeding. This forces every spec to consider its neighbors, not just itself.
 
-
-
 ---
 
 ### **IX. Architectural Review — Multi-Word Symbol Analysis**
@@ -289,9 +287,6 @@ Multi-word symbols are an indicator of poorly architected code, because they can
 **How to apply:** During adversarial review (Phase 3) and refactoring (Phase 2c), scan for multi-word symbols. For each one, determine: (a) should this be a method on an object? (b) does the name need qualification, or is the scope unambiguous? (c) if qualification is genuinely needed, is the scope doing too much? Also scan for error structure inconsistencies across the module boundary.
 
 ---
-
-
-
 
 ---
 


### PR DESCRIPTION
## Scope

Adds three GitHub Actions workflows under `.github/workflows/` that reflect and enforce VSDD on the canonical doc (`MEMORY.md`) itself, plus a short `## CI/CD` section in `MEMORY.md` (placed before `## Sources`) documenting them. Also adds `.github/scripts/check-memory-structure.sh`, the structural sanity check used by the gating workflow.

## Workflows added

- **`.github/workflows/issues.yml`** — VSDD Phase 1c (Spec Review Gate). Triggers on `issues: [opened, edited]`. Installs `@google/gemini-cli`, runs Gemini as Sarcasmotron against the issue body looking for ambiguous wording, missing edge cases, implicit assumptions, contradictions, lazy verification boundaries, purity-boundary violations, and verification-tool mismatches. Tries `gemini-3-pro-preview`, falls back to `gemini-2.5-pro`. Uses `--yolo` for non-interactive runs. Posts the result back as an issue comment. **Advisory only — does not gate.**
- **`.github/workflows/pulls.yml`** — VSDD Phase 3 (Adversarial Refinement). Triggers on `pull_request: [opened, synchronize, reopened]`. Two reviewers run in parallel for cognitive diversity per `MEMORY.md` §V:
  - Gemini reviews the diff (with the same model fallback and `--yolo`) and posts findings.
  - Claude reviews via the official `anthropics/claude-code-action@v1` and posts findings.
  Each is prompted to find spec-fidelity gaps, weak/tautological tests, code-quality smells, security surface issues, multi-word symbol smells (§IX), 4-Result-Rule violations (§VIII), and spec-discipline violations (§VII). **Advisory only — does not gate the merge.**
- **`.github/workflows/test.yml`** — the **gating** workflow required by the branch-protection rule on `main`. Triggers on `push` to `main` and on `pull_request`. Three jobs:
  1. `markdownlint-cli2-action` over all `*.md`.
  2. `lycheeverse/lychee-action` over `MEMORY.md`, with `json-schema.org` and `spec.openapis.org` excluded to dodge their rate limits.
  3. Structural sanity — `bash .github/scripts/check-memory-structure.sh` asserts `MEMORY.md` still contains all nine Roman-numeral section headings (`### **I.` through `### **IX.`).

All three workflows also expose `workflow_call:` triggers, so other sw2m repos can reuse them (see "Reusable" below).

## Secrets required

These need to be added to the repo's Actions secrets (`Settings → Secrets and variables → Actions`). They are **not** included in this PR.

- `GEMINI_API_KEY` — used by `issues.yml` and the `gemini-review` job in `pulls.yml`.
- `CLAUDE_CODE_OAUTH_TOKEN` — used by the `claude-review` job in `pulls.yml` (per the [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) docs).

Without these, the advisory jobs will fail at runtime, but they still won't block merges since they aren't gating.

## Reusable

Each workflow has a `workflow_call:` trigger so other `sw2m` repos can reference them:

```yaml
jobs:
  vsdd-issues:
    uses: sw2m/philosophies/.github/workflows/issues.yml@main
    secrets: inherit
  vsdd-pulls:
    uses: sw2m/philosophies/.github/workflows/pulls.yml@main
    secrets: inherit
  vsdd-test:
    uses: sw2m/philosophies/.github/workflows/test.yml@main
```

This keeps `sw2m/philosophies` as the canonical source of the VSDD CI/CD shape.

## Test plan

Once `GEMINI_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are set in repo secrets:

- [ ] **Issues workflow:** open a throwaway issue with deliberately ambiguous wording (e.g. "Make the system handle errors better"). Confirm the workflow runs and posts a Phase 1c comment.
- [ ] **Issues edit path:** edit that issue body. Confirm the workflow re-runs and posts a fresh comment.
- [ ] **Pulls workflow (Gemini):** push a small PR (e.g. fix a typo). Confirm the `gemini-review` job posts a comment.
- [ ] **Pulls workflow (Claude):** same PR — confirm the `claude-review` job posts a comment.
- [ ] **Pulls workflow (cognitive diversity):** open a PR with a deliberate VSDD smell (e.g. add a `camelCase` multi-word var to a code sample). Confirm at least one of the two reviewers flags it per §IX.
- [ ] **Test workflow — markdownlint:** introduce a markdown lint violation in a feature branch and confirm the `markdownlint` job fails.
- [ ] **Test workflow — lychee:** add a known-broken external link to `MEMORY.md` on a feature branch and confirm the `linkcheck` job fails.
- [ ] **Test workflow — structural sanity:** delete `### **VII. Spec Discipline ...` on a feature branch and confirm the `structural-sanity` job fails with the missing-heading message.
- [ ] **Reusable from another repo:** in a sibling sw2m repo, add a workflow with `uses: sw2m/philosophies/.github/workflows/test.yml@main` and confirm it runs.

## Verification done in this PR

- `python3 -c "import yaml; yaml.safe_load(open(...))"` on all three workflow YAMLs — all parse cleanly.
- `bash .github/scripts/check-memory-structure.sh` — passes ("OK: MEMORY.md contains all 9 Roman-numeral section headings.").
- Manually confirmed `MEMORY.md` still has all of §I through §IX, plus the new `## CI/CD` section before `## Sources`.

## Out of scope

- Wiring the branch-protection rule on `main` to require `test.yml`. This PR adds the workflow; the protection rule itself is configured in repo settings, not in code.
- Mutation testing, formal-verification harnesses, fuzz-testing CI (Phase 5 hardening per `MEMORY.md` §II). Deferred until there's actual non-doc code in this repo.
- Cross-repo distribution mechanics for `sw2m` consumers. The `workflow_call` hooks are in place; rolling them out to sibling repos is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)