### PR TITLE
fix(pulls): expand §IX coverage in Phase 3 prompts (closes #6, #15)

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -72,7 +72,12 @@ env:
     - Code that diverges from the spec it's supposed to satisfy
     - Tautological tests
     - Hidden coupling, race conditions, missing cleanup
-    - Multi-word symbols that should be `Subject.verb` (§IX)
+    - Multi-word symbols (camelCase / snake_case), per §IX:
+      - Functions/methods: should they be `Subject.verb` on a state machine?
+      - Vars at large: is the symbol genuinely ambiguous, or is it verbose-when-unambiguous? `archiveUrl` reduces to `archive` or `url`.
+      - Localized/scoped collisions: if multi-word is forced by collision, the scope is doing too much.
+      - Do NOT flag: PascalCase types/classes/interfaces; serde-leak fields whose name matches an at-rest schema (`c_type` matching a YAML/JSON field); external-library symbols you don't control.
+    - Error-structure inconsistency (§IX): mixed error types, mixed throw/return/null, partial error-code coverage, try/catch vs assertThrows mismatches.
     - Inconsistent error handling
     - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
 


### PR DESCRIPTION
## Summary

Closes #6 and closes #15 (duplicates).

The Phase 3 review prompt previously condensed the §IX multi-word-symbol rule into a single bullet (`Multi-word symbols that should be Subject.verb (§IX)`), which only covers one of the three failure modes documented in `MEMORY.md` §IX.

This PR replaces that bullet — once, inside `env.PHASE_3_PROMPT` — with a fuller block that enumerates:

- All three §IX failure modes:
  1. Multi-word *function/method* symbols → should be `Subject.verb` on a state machine.
  2. Multi-word *vars at large* → only justified when genuinely ambiguous; verbose-when-unambiguous (`archiveUrl` → `archive` or `url`) is a smell.
  3. Multi-word *localized/scoped* symbols → if multi-word is forced by collision, the scope is doing too much.
- The documented exceptions reviewers must NOT flag: PascalCase types/classes/interfaces, serde-leak fields whose name matches an at-rest schema, and external-library symbols.
- The §IX error-structure-inconsistency check (mixed error types, mixed throw/return/null, partial error-code coverage, try/catch vs assertThrows mismatches).

Prompts stay terse — bullets, not paragraphs — since the reviewer's job is to flag instances, not re-derive §IX.

## Rebased on top of #27, #32, #38

Branch was stale (base predated #28's prompt-dedup, #32's promote pipeline + ownership gate, #38's labels fix, and #27's semantic dedup). Rebased cleanly onto current `main`; the diff stat shrank to **+6 / −1** because the §IX block now lives in exactly one place: `env.PHASE_3_PROMPT`. Both reviewer call sites consume that env var — no duplicate inline edits.

Out of scope for this PR (deliberately):
- The §IX block is **not** also added to `promote-tech-to-pr`'s Phase 4 prompt or to `symbol-audit.sh` (PR #22). Those audiences serve different purposes (implementation vs static check) — bundling defeats §VII.

## Test plan

- [ ] CI passes (`test.yml` + Phase 3 adversarial review + `ci-meta` consensus).
- [ ] On a follow-up PR that intentionally introduces a §IX-mode-2 or mode-3 violation, confirm the Phase 3 reviewers now flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)