### PR TITLE
fix(pulls): surface diff-truncation as blocking warning in Phase 3 reviews (closes #16)

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -67,6 +67,14 @@ env:
 
     Critical: if you find yourself citing a file or symbol that isn't actually present in the embedded diff, STOP — that is a hallucination. Only cite what's in the embedded content.
 
+    # DIFF-TRUNCATION CHECK
+
+    If you see `[diff truncated to 5000 lines]` anywhere in the embedded diff, START your review's body (after the frontmatter) with this exact bullet:
+
+    `- **(blocking) DIFF TRUNCATED.** This review only saw the first 5000 lines of the diff. The human reviewer must read the rest of the diff manually before merging.`
+
+    That bullet must appear before any other findings. Set `verdict: fail` because partial coverage is a correctness concern. This rule overrides the usual pass-with-nitpicks logic.
+
     Apply these review rules. Look ONLY for:
 
     - Code that diverges from the spec it's supposed to satisfy
@@ -194,6 +202,10 @@ jobs:
             mv pr.diff.trunc pr.diff
             echo "" >> pr.diff
             echo "[diff truncated to 5000 lines]" >> pr.diff
+            # Empty marker file so downstream consumers can detect truncation
+            # deterministically without grepping the diff body (the marker
+            # string itself could legitimately appear inside a diff hunk).
+            : > pr.diff.truncated
           fi
 
       - name: Build prompts (gemini + claude)


### PR DESCRIPTION
## Summary

Closes #16.

When `pr.diff` exceeds 5000 lines, the prep step truncates it and appends `[diff truncated to 5000 lines]`. Until now, the AI reviewers (Gemini + Claude) could still emit `verdict: pass` without ever telling the human reviewer that their coverage was partial. That defeats the safety story: a `pass` from a model that only saw the first 5000 lines is dishonest.

Changes (all in `.github/workflows/pulls.yml`):

- **Truncation marker file.** When truncation occurs, also write an empty `pr.diff.truncated` file. Downstream consumers can detect truncation deterministically by file existence rather than grepping the diff body (where the marker string could legitimately appear inside a hunk).
- **Gemini prompt.** Added a `# DIFF-TRUNCATION CHECK` block near the top instructing the reviewer that if the truncation marker is present in the embedded diff, the body MUST start with a specific verbatim blocking bullet, and `verdict: fail` is mandatory. Rationale stated: partial coverage is itself a correctness concern.
- **Claude prompt.** Same `# DIFF-TRUNCATION CHECK` block added to the Claude prompt with identical wording.

The verdict=fail rule is non-negotiable in the truncation case: if the model can't see the whole diff, it cannot honestly reach `pass`. This rule is documented as overriding the usual pass/fail criteria.

## Test plan

- [ ] YAML validates (already verified locally with `python3 -c yaml.safe_load`).
- [ ] On a small PR (<5000-line diff), behavior is unchanged: no truncation marker file, no truncation bullet, normal pass/fail criteria apply.
- [ ] On a synthetic large PR (>5000-line diff), confirm `pr.diff.truncated` is created and both AI reviews start their body with the exact blocking bullet and emit `verdict: fail`.

---

Draft — ready for human review of prompt wording before promotion.