### PR TITLE
feat(ci-meta): add explicit repo-shape detection for §VIII applicability (closes #4)

### DIFF
--- a/.github/actions/repo-shape/action.yml
+++ b/.github/actions/repo-shape/action.yml
@@ -1,0 +1,71 @@
+name: "Detect repo shape"
+description: |
+  Inspects the consuming repo at the current checkout and emits whether it
+  has a test suite. Used by ci-meta to make VSDD §VIII (4-Result Rule) and
+  Phase 2a/2b applicability EXPLICIT in the reviewer prompts and the run
+  summary, instead of letting reviewers infer "this is a docs repo" from
+  context alone.
+
+  Heuristic for `has-tests`: true if ANY of the following exist at the repo
+  root:
+    - package.json
+    - deno.json
+    - Cargo.toml
+    - go.mod
+    - pyproject.toml
+    - tsconfig.json
+    - tests/ directory
+    - test/ directory
+
+  Heuristic for `repo-kind`:
+    - `code` if `has-tests` is true
+    - `docs` otherwise
+
+  These outputs are intentionally coarse — the goal is to flip the
+  `2a/2b/§VIII` line in the reviewer prompt between "ENFORCED" and "N/A
+  (no test suite detected)", and to print that same line into
+  $GITHUB_STEP_SUMMARY for human auditors.
+
+outputs:
+  has-tests:
+    description: "true if the repo appears to have a test suite (see heuristics in the description)."
+    value: ${{ steps.detect.outputs.has-tests }}
+  repo-kind:
+    description: "'code' if has-tests is true; 'docs' otherwise."
+    value: ${{ steps.detect.outputs.repo-kind }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect repo shape
+      id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+        has_tests="false"
+        reason=""
+        for marker in package.json deno.json Cargo.toml go.mod pyproject.toml tsconfig.json; do
+          if [ -f "$marker" ]; then
+            has_tests="true"
+            reason="found $marker"
+            break
+          fi
+        done
+        if [ "$has_tests" = "false" ]; then
+          for dir in tests test; do
+            if [ -d "$dir" ]; then
+              has_tests="true"
+              reason="found $dir/ directory"
+              break
+            fi
+          done
+        fi
+        if [ "$has_tests" = "true" ]; then
+          repo_kind="code"
+        else
+          repo_kind="docs"
+          reason="no test-suite markers detected"
+        fi
+        echo "has-tests=$has_tests" >> "$GITHUB_OUTPUT"
+        echo "repo-kind=$repo_kind" >> "$GITHUB_OUTPUT"
+        echo "repo shape: has-tests=$has_tests repo-kind=$repo_kind ($reason)"

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -50,9 +50,38 @@ jobs:
   # `.github/actions/gemini` and `.github/actions/claude` so it is impossible
   # to invoke an agent without going through it.
 
+  repo-shape:
+    name: Detect repo shape (code vs docs)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    outputs:
+      has-tests: ${{ steps.shape.outputs.has-tests }}
+      repo-kind: ${{ steps.shape.outputs.repo-kind }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: shape
+        uses: ./.github/actions/repo-shape
+      - name: Print VSDD §VIII applicability to job summary
+        shell: bash
+        env:
+          HAS_TESTS: ${{ steps.shape.outputs.has-tests }}
+          REPO_KIND: ${{ steps.shape.outputs.repo-kind }}
+        run: |
+          if [ "$HAS_TESTS" = "true" ]; then
+            status="ENFORCED"
+          else
+            status="N/A (no test suite detected)"
+          fi
+          line="VSDD 2a/2b/§VIII: $status"
+          echo "$line"
+          echo "- repo-kind: \`$REPO_KIND\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- has-tests: \`$HAS_TESTS\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- $line" >> "$GITHUB_STEP_SUMMARY"
+
   prep:
     name: Prepare evaluation input
     if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    needs: [repo-shape]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -101,7 +130,7 @@ jobs:
 
   gemini-eval:
     name: Gemini VSDD CI evaluation
-    needs: [prep]
+    needs: [prep, repo-shape]
     runs-on: ubuntu-latest
     outputs:
       verdict: ${{ steps.parse.outputs.verdict }}
@@ -125,6 +154,21 @@ jobs:
             Read each CI workflow file inside <workflow path="..."> tags.
             Read each composite action file inside <action path="..."> tags.
 
+            Repo-shape context (detected by `.github/actions/repo-shape`, which
+            looks for package.json / deno.json / Cargo.toml / go.mod /
+            pyproject.toml / tsconfig.json / a `tests/` or `test/` directory):
+
+            <repo-kind>${{ needs.repo-shape.outputs.repo-kind }}</repo-kind>
+            <has-tests>${{ needs.repo-shape.outputs.has-tests }}</has-tests>
+
+            Use this context to decide §VIII applicability EXPLICITLY:
+            - if <repo-kind>code</repo-kind>, Phase 2a/2b and the 4-Result
+              Rule (§VIII) are applicable; classify them ENFORCED / PARTIAL /
+              MISSING normally.
+            - if <repo-kind>docs</repo-kind>, Phase 2a/2b and §VIII are NOT
+              applicable; mark them `N/A` and state the reason ("no test
+              suite detected by repo-shape"). Do NOT mark them MISSING.
+
             Evaluate whether the workflows correctly enforce VSDD requirements:
             - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against §VII spec discipline.
             - Phase 2a (Red Gate): a mechanism that confirms tests fail before implementation lands.
@@ -134,9 +178,9 @@ jobs:
             - §IX: multi-word symbol audit (camelCase/snake_case scan on code PRs).
             - Spec discipline (§VII): tech specs are discrete; goal specs are bulk.
 
-            Classify each requirement: ENFORCED, PARTIAL, or MISSING.
-
-            A repo with no test suite (e.g. sw2m/philosophies — a docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A in that case, not MISSING.
+            Classify each requirement: ENFORCED, PARTIAL, MISSING, or N/A
+            (the last only for items the repo-shape context above marks
+            inapplicable).
 
             # OUTPUT FORMAT (strict)
 
@@ -219,7 +263,7 @@ jobs:
 
   claude-eval:
     name: Claude VSDD CI evaluation
-    needs: [prep]
+    needs: [prep, repo-shape]
     runs-on: ubuntu-latest
     outputs:
       verdict: ${{ steps.parse.outputs.verdict }}
@@ -275,6 +319,22 @@ jobs:
             <action path="..."> tags. Do NOT look for files on disk; only
             cite content that is present in the embedded text.
 
+            Repo-shape context (detected by `.github/actions/repo-shape`,
+            which looks for package.json / deno.json / Cargo.toml / go.mod
+            / pyproject.toml / tsconfig.json / a `tests/` or `test/`
+            directory):
+
+            <repo-kind>${{ needs.repo-shape.outputs.repo-kind }}</repo-kind>
+            <has-tests>${{ needs.repo-shape.outputs.has-tests }}</has-tests>
+
+            Use this context to decide §VIII applicability EXPLICITLY:
+            - if <repo-kind>code</repo-kind>, Phase 2a/2b and the 4-Result
+              Rule (§VIII) are applicable; classify them ENFORCED / PARTIAL
+              / MISSING normally.
+            - if <repo-kind>docs</repo-kind>, Phase 2a/2b and §VIII are NOT
+              applicable; mark them `N/A` and state the reason ("no test
+              suite detected by repo-shape"). Do NOT mark them MISSING.
+
             Evaluate whether the workflows correctly enforce VSDD requirements:
             - Phase 1c (Spec Review Gate): adversarial review of new/edited issues against §VII spec discipline.
             - Phase 2a (Red Gate): tests fail before implementation; CI confirms.
@@ -283,8 +343,6 @@ jobs:
             - Phase 3: adversarial review of code changes.
             - §IX: multi-word symbol audit.
             - Spec discipline (§VII): tech specs are discrete.
-
-            A repo with no test suite (docs repo) cannot enforce 2a/2b/§VIII; treat those as N/A, not MISSING.
 
             # OUTPUT FORMAT (strict)
 


### PR DESCRIPTION
## Summary

Closes #4. Makes the "this is a docs repo, Phase 2a/2b/§VIII don't apply" status **explicit and auditable** instead of leaving it as an implicit inference inside the reviewer prompt.

- New composite action `.github/actions/repo-shape` classifies the consuming repo as `code` or `docs`.
- New top-level `repo-shape` job in `ci-meta.yml` runs the action before `prep` and exposes `has-tests` / `repo-kind` outputs.
- Both Gemini and Claude prompts now receive `<repo-kind>` / `<has-tests>` context tags and are instructed to mark 2a/2b/§VIII as `N/A` (not `MISSING`) when `repo-kind=docs`.
- A one-line `VSDD 2a/2b/§VIII: <ENFORCED | N/A (no test suite detected)>` is appended to `$GITHUB_STEP_SUMMARY` so a human auditing the run sees applicability without parsing the prompt.

## `has-tests` heuristics

`has-tests` is `true` if any of the following exist at the repo root:

- `package.json`
- `deno.json`
- `Cargo.toml`
- `go.mod`
- `pyproject.toml`
- `tsconfig.json`
- a `tests/` directory
- a `test/` directory

`repo-kind` is `code` when `has-tests` is `true`, else `docs`.

## Notes

- Draft PR per the issue. Do not promote until the meta-CI run on this PR is reviewed.
- Did not touch `pulls.yml`, `issues.yml`, or `MEMORY.md`.
- Both touched YAML files validated with `yaml.safe_load`.

## Test plan

- [ ] Meta-CI run on this PR shows the `Detect repo shape (code vs docs)` job emitting `repo-kind=docs` / `has-tests=false`.
- [ ] Job summary on this run contains the line `VSDD 2a/2b/§VIII: N/A (no test suite detected)`.
- [ ] Gemini and Claude verdicts mark 2a/2b/§VIII as `N/A` (not `MISSING`).