### PR TITLE
feat(ci-meta): semantic dedup of pre-existing gap issues via Gemini

### DIFF
--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -406,14 +406,13 @@ jobs:
           name: claude-eval
           path: ./eval/
 
-      - name: Reach consensus + open gap issues
+      - name: Build proposed gaps + fetch existing tracked gaps
+        id: prep-dedup
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           python3 - <<'PY'
-          import json, os, re, subprocess, sys
+          import json, os, re, subprocess
 
           with open('eval/gemini-eval.json') as f:
               gemini = json.load(f)
@@ -428,6 +427,10 @@ jobs:
 
           fail = gemini['verdict'] == 'fail' or claude['verdict'] == 'fail'
 
+          # Merge the two reviewers' gap lists. Keep the title-similarity
+          # merge (collapses near-identical titles flagged by both sides
+          # into one entry); semantic dedup against ALREADY-tracked gaps
+          # happens in the next step via Gemini.
           all_gaps = []
           for g in gemini.get('gaps', []):
               all_gaps.append({**g, 'flagged_by': ['gemini']})
@@ -442,9 +445,189 @@ jobs:
               if not merged:
                   all_gaps.append({**g, 'flagged_by': ['claude']})
 
+          with open('proposed-gaps.json', 'w') as f:
+              json.dump(all_gaps, f)
+          with open('verdicts.json', 'w') as f:
+              json.dump({'fail': fail, 'gemini': gemini, 'claude': claude}, f)
+
+          # Fetch ALL ci-meta-labeled issues regardless of state so a
+          # closed-without-PR issue (the primary failure mode of the old
+          # exact-title dedup) still functions as a dedup candidate.
+          # Pre-existing tracked gaps in any state are candidates; the
+          # semantic-dedup agent decides matching, not state.
+          candidates = []
+          if all_gaps:
+              r = subprocess.run(
+                  ['gh', 'issue', 'list', '--state', 'all', '--label', 'ci-meta',
+                   '--limit', '200',
+                   '--json', 'number,title,body,state,stateReason'],
+                  capture_output=True, text=True, check=True,
+              )
+              candidates = json.loads(r.stdout)
+          with open('existing-issues.json', 'w') as f:
+              json.dump(candidates, f)
+
+          print(f"proposed gaps: {len(all_gaps)} | existing ci-meta issues: {len(candidates)}")
+          out = os.environ['GITHUB_OUTPUT']
+          with open(out, 'a') as f:
+              f.write(f"proposed-count={len(all_gaps)}\n")
+              f.write(f"candidate-count={len(candidates)}\n")
+              dedup = 'true' if (all_gaps and candidates) else 'false'
+              f.write(f"dedup-needed={dedup}\n")
+          PY
+
+      - name: Build Gemini dedup input
+        if: steps.prep-dedup.outputs.dedup-needed == 'true'
+        run: |
+          python3 - <<'PY'
+          import json
+          with open('proposed-gaps.json') as f: proposed = json.load(f)
+          with open('existing-issues.json') as f: existing = json.load(f)
+
+          def _truncate(s, n=4000):
+              s = (s or '').strip()
+              return s if len(s) <= n else s[:n] + '\n... [truncated]'
+
+          out = []
+          out.append("# CRITICAL OUTPUT FORMAT (read FIRST)")
+          out.append("")
+          out.append("Your response MUST start with YAML frontmatter on the very first line — no preamble, no leading whitespace. Concrete shape:")
+          out.append("")
+          out.append("```")
+          out.append("---")
+          out.append("verdicts:")
+          out.append("  - proposed_index: 0")
+          out.append("    duplicate_of: 42  # existing issue number, OR null if no semantic match")
+          out.append("    rationale: |")
+          out.append("      one short line explaining the call")
+          out.append("  - proposed_index: 1")
+          out.append("    duplicate_of: null")
+          out.append("    rationale: |")
+          out.append("      ...")
+          out.append("---")
+          out.append("```")
+          out.append("")
+          out.append("# TASK")
+          out.append("")
+          out.append("Deduplicate proposed CI gap issues against pre-existing tracked gaps in this repo. Two gaps are SEMANTIC DUPLICATES when they describe the same underlying CI gap — same root cause, same VSDD section, same observable symptom — even if their titles or wording differ. Match on substance, not title.")
+          out.append("")
+          out.append("Closed issues are still valid dedup candidates. The maintainer who closed an issue (with or without a linked PR) made a judgment that should not be re-litigated by re-flagging. The PRIMARY failure mode this is meant to catch: an issue closed without a PR (closed because it was deemed low-value, wontfix, or out of scope) gets re-flagged on the next meta-CI run because the gap technically still exists. That should be a duplicate.")
+          out.append("")
+          out.append("Match conservatively. Only call something a duplicate if you are confident the substance overlaps — when in doubt, return null and let the human decide.")
+          out.append("")
+          out.append("Output one verdict per proposed gap, in order. `proposed_index` is 0-based and must match the `<proposed index=N>` blocks below.")
+          out.append("")
+          out.append("--- EXISTING TRACKED GAPS ---")
+          for e in existing:
+              out.append("")
+              out.append(f'<issue number="{e["number"]}" state="{e["state"]}" stateReason="{e.get("stateReason","")}">')
+              out.append(f"<title>{e['title']}</title>")
+              out.append("<body>")
+              out.append(_truncate(e.get('body', '')))
+              out.append("</body>")
+              out.append("</issue>")
+          out.append("")
+          out.append("--- PROPOSED NEW GAPS ---")
+          for i, p in enumerate(proposed):
+              out.append("")
+              out.append(f'<proposed index="{i}">')
+              out.append(f"<title>{p['title']}</title>")
+              out.append("<body>")
+              out.append(_truncate(p.get('body', '')))
+              out.append("</body>")
+              out.append("</proposed>")
+
+          with open('dedup-input.txt', 'w') as f:
+              f.write('\n'.join(out))
+          import os
+          print(f"dedup-input.txt: {os.path.getsize('dedup-input.txt')} bytes")
+          PY
+
+      - name: Run Gemini semantic dedup
+        if: steps.prep-dedup.outputs.dedup-needed == 'true'
+        uses: ./.github/actions/gemini
+        with:
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          stdin-file: dedup-input.txt
+          output-file: dedup-output.md
+          # PR author is who triggered the meta-review; for self-eval the
+          # author is always an org member. Threading actor-override here
+          # is defensive in case a `synchronize` event lands with a
+          # different sender on a fork-PR.
+          actor-override: ${{ github.event.pull_request.user.login }}
+
+      - name: Open non-duplicate gap issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          python3 - <<'PY'
+          import json, os, re, subprocess, sys, yaml
+
+          with open('proposed-gaps.json') as f: proposed = json.load(f)
+          with open('verdicts.json')      as f: vs = json.load(f)
+          with open('existing-issues.json') as f: existing = json.load(f)
+          existing_by_num = {e['number']: e for e in existing}
+
+          # proposed_index -> existing issue number
+          duplicate_map = {}
+          dedup_source = 'none'
+
+          if os.path.exists('dedup-output.md'):
+              with open('dedup-output.md') as f:
+                  raw = f.read()
+              # Frontmatter parse — strict-top, then embedded fallback.
+              fm = None
+              m = re.match(r'^\s*---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$', raw)
+              if m:
+                  try: fm = yaml.safe_load(m.group(1))
+                  except yaml.YAMLError: fm = None
+              if not isinstance(fm, dict) or 'verdicts' not in fm:
+                  m2 = re.search(r'\n---\s*\n(verdicts\s*:[\s\S]*?)\n---\s*\n', raw)
+                  if m2:
+                      try: fm = yaml.safe_load(m2.group(1))
+                      except yaml.YAMLError: fm = None
+              if isinstance(fm, dict) and isinstance(fm.get('verdicts'), list):
+                  for v in fm['verdicts']:
+                      idx = v.get('proposed_index')
+                      dup = v.get('duplicate_of')
+                      if isinstance(idx, int) and isinstance(dup, int) and dup in existing_by_num:
+                          duplicate_map[idx] = dup
+                  dedup_source = 'gemini'
+                  print(f"Gemini flagged {len(duplicate_map)}/{len(proposed)} as semantic duplicates.")
+              else:
+                  print('::warning::Gemini dedup output unparseable; falling back to title-exact match against open issues.', file=sys.stderr)
+
+          # Defensive fallback: when Gemini didn't run (no candidates) OR
+          # produced unparseable output, still skip OPEN issues with the
+          # exact same title. Reduces noise while preserving the
+          # intent-of-the-PR semantic dedup as the primary path.
+          if dedup_source != 'gemini':
+              for i, p in enumerate(proposed):
+                  if i in duplicate_map:
+                      continue
+                  r = subprocess.run(
+                      ['gh', 'issue', 'list', '--state', 'open', '--search', p['title'],
+                       '--json', 'number,title'],
+                      capture_output=True, text=True, check=True,
+                  )
+                  for item in json.loads(r.stdout):
+                      if item['title'] == p['title']:
+                          duplicate_map[i] = item['number']
+                          break
+              if duplicate_map:
+                  dedup_source = 'title-exact-fallback'
+                  print(f"Fallback flagged {len(duplicate_map)}/{len(proposed)} as title-exact duplicates of open issues.")
+
           pr_url = os.environ.get('PR_URL', '')
-          opened = []
-          for g in all_gaps:
+          opened = []  # parallel to `proposed`; URL or None
+          for i, g in enumerate(proposed):
+              if i in duplicate_map:
+                  dup_num = duplicate_map[i]
+                  print(f"  skip (semantic dup of #{dup_num}): {g['title']}")
+                  opened.append(None)
+                  continue
               flagged_by = ' + '.join(sorted(g['flagged_by']))
               body = (
                   f"_Flagged by **{flagged_by}** in the VSDD CI meta-review._\n\n"
@@ -452,27 +635,15 @@ jobs:
                   f"---\n"
                   f"PR triggering this evaluation: {pr_url or '(self-evaluation)'}\n"
               )
-              search = subprocess.run(
-                  ['gh', 'issue', 'list', '--state', 'open', '--search', g['title'], '--json', 'number,title'],
-                  capture_output=True, text=True, check=True,
-              )
-              existing = json.loads(search.stdout)
-              if any(item['title'] == g['title'] for item in existing):
-                  print(f"  skip (already open): {g['title']}")
-                  continue
               # `spec:goal` enables the assignment-triggered promotion
-              # pipeline (promote.yml). When an org member self-assigns
-              # this issue, promote-goal-to-tech decomposes it into
-              # tech-spec sub-issues. `ci-meta` is provenance only.
+              # pipeline (promote.yml). `ci-meta` is provenance.
               r = subprocess.run(
                   ['gh', 'issue', 'create', '--title', g['title'], '--body', body,
                    '--label', 'ci-meta', '--label', 'spec:goal'],
                   capture_output=True, text=True,
               )
               if r.returncode != 0:
-                  # Labels may not exist yet on first run of this workflow
-                  # in a downstream repo. Fall back to label-less creation
-                  # so a missing label doesn't block tracking the gap.
+                  # Labels may not exist on first run in a downstream repo.
                   r = subprocess.run(
                       ['gh', 'issue', 'create', '--title', g['title'], '--body', body],
                       capture_output=True, text=True, check=True,
@@ -481,39 +652,49 @@ jobs:
               print(f"  opened: {url}")
               opened.append(url)
 
+          # Step summary + consensus state.
+          fail   = vs['fail']
+          gemini = vs['gemini']
+          claude = vs['claude']
           summary = os.environ.get('GITHUB_STEP_SUMMARY')
           if summary:
               with open(summary, 'a') as f:
-                  f.write(f"# VSDD CI Meta-Review\n\n")
+                  f.write("# VSDD CI Meta-Review\n\n")
                   f.write(f"- Gemini: **{gemini['verdict']}**\n")
                   f.write(f"- Claude: **{claude['verdict']}**\n")
-                  f.write(f"- Consensus: **{'fail' if fail else 'pass'}**\n\n")
-                  if all_gaps:
-                      f.write(f"## Gaps ({len(all_gaps)})\n\n")
-                      for g, url in zip(all_gaps, opened or [None] * len(all_gaps)):
+                  f.write(f"- Consensus: **{'fail' if fail else 'pass'}**\n")
+                  f.write(f"- Dedup: **{dedup_source}**\n\n")
+                  if proposed:
+                      f.write(f"## Gaps ({len(proposed)})\n\n")
+                      for i, g in enumerate(proposed):
                           flagged_by = ' + '.join(sorted(g['flagged_by']))
-                          f.write(f"- {g['title']} _(flagged by {flagged_by})_")
-                          if url:
-                              f.write(f" — {url}")
-                          f.write("\n")
+                          line = f"- {g['title']} _(flagged by {flagged_by})_"
+                          if i in duplicate_map:
+                              line += f" — _skipped: dup of #{duplicate_map[i]}_"
+                          elif opened[i]:
+                              line += f" — {opened[i]}"
+                          f.write(line + "\n")
 
-          # Stash the consensus state for the PR-review step downstream.
           state = {
               'verdict': 'fail' if fail else 'pass',
               'gemini_verdict': gemini['verdict'],
               'claude_verdict': claude['verdict'],
               'gemini_rationale': gemini.get('rationale', ''),
               'claude_rationale': claude.get('rationale', ''),
-              'gaps': all_gaps,
-              'opened_issue_urls': opened,
+              'gaps': proposed,
+              'opened_issue_urls': [u for u in opened if u],
+              'duplicate_map': duplicate_map,
+              'dedup_source': dedup_source,
           }
           with open('consensus-state.json', 'w') as f:
               json.dump(state, f, indent=2)
 
+          opened_count = sum(1 for u in opened if u)
+          skipped_count = len(duplicate_map)
           if fail:
-              print(f"\nFAIL: {len(all_gaps)} gap issue(s) opened or already open.")
+              print(f"\nFAIL: {opened_count} gap issue(s) opened, {skipped_count} skipped as duplicates.")
               sys.exit(1)
-          print("\nPASS: both reviewers agree the CI enforces VSDD correctly.")
+          print(f"\nPASS: {opened_count} opened, {skipped_count} skipped as duplicates.")
           PY
 
       - name: Submit consensus PR review (APPROVE / REQUEST_CHANGES)


### PR DESCRIPTION
## Summary

Replaces the exact-title, 4-case dedup in `consensus` with a **semantic** dedup against **pre-existing** ci-meta-tracked gaps in any state. Closed-without-PR was the primary failure mode the prior version targeted; that case is now subsumed by the broader rule — Gemini sees the closed issue alongside the proposed gap and matches on substance.

## What changed

The `consensus` step is split into four:

1. **prep-dedup** — merge Gemini + Claude gap lists; write `proposed-gaps.json`. Fetch every `--label ci-meta --state all` issue with title + body + state + stateReason; write `existing-issues.json`.
2. **Build Gemini dedup input** — render both lists into a single stdin file with the standard `<issue number=…>` / `<proposed index=…>` tags.
3. **Run Gemini semantic dedup** — `uses: ./.github/actions/gemini` (composite). Output: YAML frontmatter `verdicts:` array, one entry per proposed gap, mapping `proposed_index` → `duplicate_of: <issue#> | null`.
4. **Open non-duplicate gap issues** — consume Gemini's verdicts; skip duplicates; open the rest with `ci-meta` + `spec:goal`. Writes `consensus-state.json` for the downstream PR-review step (unchanged).

### Why semantic, not title-exact

| Failure mode the old logic missed | What the semantic check catches |
|---|---|
| Reviewers rephrase the same gap on each run (`[ci-meta] add red gate` vs `[ci-meta] no Phase 2a enforcement`) | Same root cause → matched as duplicate |
| Maintainer closed an issue with a comment ("not relevant for docs repo") and no linked PR | Still matched — closed issues remain dedup candidates |
| Maintainer closed via PR but the gap re-surfaces because the fix was incomplete | Still matched (Gemini decides; if substance overlaps, it's a dup; the human re-opens if desired) |

### Defensive fallback

When `existing-issues.json` is empty (cold start, no prior ci-meta gaps) the Gemini call is skipped entirely. When Gemini's output is unparseable, the loop falls back to a **title-exact match against open issues only** — the same baseline behavior as before this PR. So a Gemini outage downgrades to old-style dedup, never to "open everything blindly."

### File scope

| Path | Change |
|---|---|
| `.github/workflows/ci-meta.yml` | `consensus` step rewritten (215 insertions, 34 deletions) |

No other files touched. The `consensus-state.json` shape gains two new keys (`duplicate_map`, `dedup_source`) but no existing key was removed.

## Test plan

- [ ] CI passes on this PR (test.yml + ci-meta self-eval).
- [ ] After merge, the next ci-meta run shows `dedup-source: gemini` in the step summary.
- [ ] Manually flag a gap whose substance matches a previously-closed-without-PR issue (e.g. close an existing gap, re-trigger meta-CI, confirm it's skipped with `skip (semantic dup of #N)` in the log).
- [ ] Manually break the Gemini API key briefly, re-trigger; confirm fallback kicks in (`dedup-source: title-exact-fallback`) without opening duplicates of currently-open issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)