### PR TITLE
chore(pulls): factor duplicated Phase 3 prompt content into workflow env vars

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -31,12 +31,13 @@ permissions:
 # framing (gemini's stdin intro, claude's anti-hallucination guard) stays
 # inline at the call site.
 env:
-  # Shared Phase 3 prompt fragments. Both reviewers (Gemini, Claude) get the
-  # same role, rules, format spec, the strict-output preamble, and the
-  # anti-hallucination guard. Keep this the single source of truth — adding
-  # a new review rule means adding it here once.
-
-  PHASE_3_CRITICAL_FORMAT_PREAMBLE: |-
+  # Single source of truth for the Phase 3 reviewer prompt. Both reviewers
+  # (Gemini, Claude) receive this identical text — the only mechanical
+  # difference is HOW the input substrate (MEMORY.md + diff) is attached:
+  # Gemini reads it via stdin; Claude's composite action prepends this
+  # prompt to the same stdin-file. Adding a new review rule means editing
+  # this one block.
+  PHASE_3_PROMPT: |-
     # CRITICAL OUTPUT FORMAT (read this FIRST)
 
     Your response MUST start, on the very first line, with exactly `---` (no leading whitespace, no preamble), then `verdict: pass` or `verdict: fail`, then `---`, then your bullet list.
@@ -55,15 +56,14 @@ env:
     If you do not produce frontmatter as your first output, the workflow
     will fail and your review will be discarded. Non-negotiable.
 
-  PHASE_3_ROLE: |-
+    # TASK
+
     You are an adversarial Phase 3 reviewer (MEMORY.md §II — Verified Spec-Driven Development / VSDD).
 
-  PHASE_3_ANTI_HALLUCINATION: |-
     The canonical VSDD doc and the PR diff under review are EMBEDDED below in the same message — do not look for files on disk; if you cite something, cite from the embedded content.
 
     Critical: if you find yourself citing a file or symbol that isn't actually present in the embedded diff, STOP — that is a hallucination. Only cite what's in the embedded content.
 
-  PHASE_3_REVIEW_RULES: |-
     Apply these review rules. Look ONLY for:
 
     - Code that diverges from the spec it's supposed to satisfy
@@ -73,7 +73,6 @@ env:
     - Inconsistent error handling
     - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
 
-  PHASE_3_OUTPUT_FORMAT: |-
     # OUTPUT FORMAT (strict)
 
     Begin your response with YAML frontmatter, exactly this shape:
@@ -142,17 +141,7 @@ jobs:
           # content gets embedded — Gemini reads stdin (this file), Claude
           # gets the same file as its `stdin-file` input.
           cat > gemini-stdin.txt <<'PROMPT_EOF'
-          ${{ env.PHASE_3_CRITICAL_FORMAT_PREAMBLE }}
-
-          # TASK
-
-          ${{ env.PHASE_3_ROLE }}
-
-          ${{ env.PHASE_3_ANTI_HALLUCINATION }}
-
-          ${{ env.PHASE_3_REVIEW_RULES }}
-
-          ${{ env.PHASE_3_OUTPUT_FORMAT }}
+          ${{ env.PHASE_3_PROMPT }}
 
           --- MEMORY.md ---
           PROMPT_EOF
@@ -239,17 +228,7 @@ jobs:
           # directly in the prompt rather than asking Claude to "read" them.
           stdin-file: gemini-stdin.txt
           prompt: |
-            ${{ env.PHASE_3_CRITICAL_FORMAT_PREAMBLE }}
-
-            # TASK
-
-            ${{ env.PHASE_3_ROLE }}
-
-            ${{ env.PHASE_3_ANTI_HALLUCINATION }}
-
-            ${{ env.PHASE_3_REVIEW_RULES }}
-
-            ${{ env.PHASE_3_OUTPUT_FORMAT }}
+            ${{ env.PHASE_3_PROMPT }}
 
       - name: Submit Claude review (APPROVE / REQUEST_CHANGES)
         uses: actions/github-script@v9

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -31,15 +31,48 @@ permissions:
 # framing (gemini's stdin intro, claude's anti-hallucination guard) stays
 # inline at the call site.
 env:
+  # Shared Phase 3 prompt fragments. Both reviewers (Gemini, Claude) get the
+  # same role, rules, format spec, the strict-output preamble, and the
+  # anti-hallucination guard. Keep this the single source of truth — adding
+  # a new review rule means adding it here once.
+
+  PHASE_3_CRITICAL_FORMAT_PREAMBLE: |-
+    # CRITICAL OUTPUT FORMAT (read this FIRST)
+
+    Your response MUST start, on the very first line, with exactly `---` (no leading whitespace, no preamble), then `verdict: pass` or `verdict: fail`, then `---`, then your bullet list.
+
+    Acceptable response example:
+
+    ```
+    ---
+    verdict: fail
+    ---
+
+    - **(blocking)** path/to/file.ts:42 — Bug description. Fix: …
+    - path/to/other.ts:10 — Nitpick. Fix: …
+    ```
+
+    If you do not produce frontmatter as your first output, the workflow
+    will fail and your review will be discarded. Non-negotiable.
+
   PHASE_3_ROLE: |-
     You are an adversarial Phase 3 reviewer (MEMORY.md §II — Verified Spec-Driven Development / VSDD).
+
+  PHASE_3_ANTI_HALLUCINATION: |-
+    The canonical VSDD doc and the PR diff under review are EMBEDDED below in the same message — do not look for files on disk; if you cite something, cite from the embedded content.
+
+    Critical: if you find yourself citing a file or symbol that isn't actually present in the embedded diff, STOP — that is a hallucination. Only cite what's in the embedded content.
+
   PHASE_3_REVIEW_RULES: |-
+    Apply these review rules. Look ONLY for:
+
     - Code that diverges from the spec it's supposed to satisfy
     - Tautological tests
     - Hidden coupling, race conditions, missing cleanup
     - Multi-word symbols that should be `Subject.verb` (§IX)
     - Inconsistent error handling
     - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
+
   PHASE_3_OUTPUT_FORMAT: |-
     # OUTPUT FORMAT (strict)
 
@@ -103,9 +136,19 @@ jobs:
 
       - name: Build prompts (gemini + claude)
         run: |
+          # Both reviewers receive the same prompt structure: the strict-output
+          # preamble first, then role, anti-hallucination guard, review rules,
+          # output format spec. The only per-reviewer difference is HOW the
+          # content gets embedded — Gemini reads stdin (this file), Claude
+          # gets the same file as its `stdin-file` input.
           cat > gemini-stdin.txt <<'PROMPT_EOF'
+          ${{ env.PHASE_3_CRITICAL_FORMAT_PREAMBLE }}
+
+          # TASK
+
           ${{ env.PHASE_3_ROLE }}
-          Review the PR diff below against the standards in MEMORY.md (§I–§IX). Look ONLY for:
+
+          ${{ env.PHASE_3_ANTI_HALLUCINATION }}
 
           ${{ env.PHASE_3_REVIEW_RULES }}
 
@@ -196,39 +239,17 @@ jobs:
           # directly in the prompt rather than asking Claude to "read" them.
           stdin-file: gemini-stdin.txt
           prompt: |
-            # CRITICAL OUTPUT FORMAT (read this FIRST)
-
-            Your response MUST start, on the very first line, with exactly `---` (no leading whitespace, no preamble), then `verdict: pass` or `verdict: fail`, then `---`, then your bullet list.
-
-            Acceptable response example:
-
-            ```
-            ---
-            verdict: fail
-            ---
-
-            - **(blocking)** path/to/file.ts:42 — Bug description. Fix: …
-            - path/to/other.ts:10 — Nitpick. Fix: …
-            ```
-
-            If you do not produce frontmatter as your first output, the workflow
-            will fail and your review will be discarded. Non-negotiable.
+            ${{ env.PHASE_3_CRITICAL_FORMAT_PREAMBLE }}
 
             # TASK
 
             ${{ env.PHASE_3_ROLE }}
-            The canonical VSDD doc and the PR diff under review are
-            EMBEDDED below in the same message — do not look for files; if
-            you cite something, cite from the embedded content. Apply
-            these review rules:
+
+            ${{ env.PHASE_3_ANTI_HALLUCINATION }}
 
             ${{ env.PHASE_3_REVIEW_RULES }}
 
             ${{ env.PHASE_3_OUTPUT_FORMAT }}
-
-            Critical: if you find yourself citing a file or symbol that
-            isn't actually present in the embedded diff, STOP — that is
-            a hallucination. Only cite what's in the embedded content.
 
       - name: Submit Claude review (APPROVE / REQUEST_CHANGES)
         uses: actions/github-script@v9

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -24,6 +24,54 @@ permissions:
   issues: write
   id-token: write
 
+# Single source of truth for the Phase 3 review prompt content. Both the
+# Gemini stdin builder (in `prep`) and the Claude `prompt:` input (in
+# `claude-review`) interpolate these via ${{ env.* }} so the review rules
+# and output-format spec live in exactly one place. Reviewer-specific
+# framing (gemini's stdin intro, claude's anti-hallucination guard) stays
+# inline at the call site.
+env:
+  PHASE_3_ROLE: |-
+    You are an adversarial Phase 3 reviewer (MEMORY.md §II — Verified Spec-Driven Development / VSDD).
+  PHASE_3_REVIEW_RULES: |-
+    - Code that diverges from the spec it's supposed to satisfy
+    - Tautological tests
+    - Hidden coupling, race conditions, missing cleanup
+    - Multi-word symbols that should be `Subject.verb` (§IX)
+    - Inconsistent error handling
+    - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
+  PHASE_3_OUTPUT_FORMAT: |-
+    # OUTPUT FORMAT (strict)
+
+    Begin your response with YAML frontmatter, exactly this shape:
+
+    ---
+    verdict: pass | fail
+    ---
+
+    The verdict answers "should this PR be approved?", **not** "are
+    there zero concerns?". A `pass` with listed nitpicks is correct
+    and expected — concerns can exist without blocking.
+
+    - `verdict: pass` ⇔ concerns are nits/style/nice-to-have. The PR
+      is acceptable as-is; the human can address the nits or dismiss
+      them. Translates to APPROVE.
+    - `verdict: fail` ⇔ at least one concern is genuinely blocking
+      (correctness, security, broken contract, spec violation that
+      invalidates the change). Translates to REQUEST_CHANGES.
+
+    The frontmatter MUST be the first thing in your output (no leading
+    whitespace, no preamble).
+
+    After the closing `---`, list every concern (blocking and
+    nitpicks alike) as terse bullets. Each bullet: a concrete flaw
+    with `file:line` and a proposed fix. Mark blocking concerns
+    explicitly with **(blocking)** at the start of the bullet so the
+    human reading can scan for them.
+
+    If you genuinely have nothing to say, the body may be a single
+    line.
+
 jobs:
   prep:
     name: Compute PR diff
@@ -56,46 +104,12 @@ jobs:
       - name: Build prompts (gemini + claude)
         run: |
           cat > gemini-stdin.txt <<'PROMPT_EOF'
-          You are an adversarial Phase 3 reviewer (MEMORY.md §II — Verified
-          Spec-Driven Development). Review the PR diff below against the
-          standards in MEMORY.md (§I–§IX). Look ONLY for:
-            - Code that diverges from the spec it's supposed to satisfy
-            - Tautological tests
-            - Hidden coupling, race conditions, missing cleanup
-            - Multi-word symbols that should be Subject.verb (§IX)
-            - Inconsistent error handling
-            - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
+          ${{ env.PHASE_3_ROLE }}
+          Review the PR diff below against the standards in MEMORY.md (§I–§IX). Look ONLY for:
 
-          # OUTPUT FORMAT (strict)
+          ${{ env.PHASE_3_REVIEW_RULES }}
 
-          Begin your response with YAML frontmatter, exactly this shape:
-
-          ---
-          verdict: pass | fail
-          ---
-
-          The verdict answers "should this PR be approved?", **not** "are
-          there zero concerns?". A `pass` with listed nitpicks is correct
-          and expected — concerns can exist without blocking.
-
-          - `verdict: pass` ⇔ concerns are nits/style/nice-to-have. The PR
-            is acceptable as-is; the human can address the nits or dismiss
-            them. Translates to APPROVE.
-          - `verdict: fail` ⇔ at least one concern is genuinely blocking
-            (correctness, security, broken contract, spec violation that
-            invalidates the change). Translates to REQUEST_CHANGES.
-
-          The frontmatter MUST be the first thing in your output (no leading
-          whitespace, no preamble).
-
-          After the closing `---`, list every concern (blocking and
-          nitpicks alike) as terse bullets. Each bullet: a concrete flaw
-          with `file:line` and a proposed fix. Mark blocking concerns
-          explicitly with **(blocking)** at the start of the bullet so the
-          human reading can scan for them.
-
-          If you genuinely have nothing to say, the body may be a single
-          line.
+          ${{ env.PHASE_3_OUTPUT_FORMAT }}
 
           --- MEMORY.md ---
           PROMPT_EOF
@@ -202,47 +216,15 @@ jobs:
 
             # TASK
 
-            You are an adversarial Phase 3 reviewer (MEMORY.md §II — VSDD).
+            ${{ env.PHASE_3_ROLE }}
             The canonical VSDD doc and the PR diff under review are
             EMBEDDED below in the same message — do not look for files; if
             you cite something, cite from the embedded content. Apply
             these review rules:
-              - Code that diverges from the spec it's supposed to satisfy
-              - Tautological tests
-              - Hidden coupling, race conditions, missing cleanup
-              - Multi-word symbols that should be `Subject.verb` (§IX)
-              - Inconsistent error handling
-              - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
 
-            # OUTPUT FORMAT (strict)
+            ${{ env.PHASE_3_REVIEW_RULES }}
 
-            Begin your written output with YAML frontmatter, exactly:
-
-            ---
-            verdict: pass | fail
-            ---
-
-            The verdict answers "should this PR be approved?", not "are
-            there zero concerns?". A `pass` with listed nitpicks is
-            correct — concerns can exist without blocking.
-
-            - `verdict: pass` ⇔ concerns are nits/style/nice-to-have.
-              Translates to APPROVE.
-            - `verdict: fail` ⇔ at least one concern is genuinely blocking
-              (correctness, security, broken contract, spec violation).
-              Translates to REQUEST_CHANGES.
-
-            The frontmatter MUST be the first thing in the file (no
-            leading whitespace, no preamble).
-
-            After the closing `---`, list every concern (blocking and
-            nitpicks alike) as terse bullets. Each bullet: a concrete
-            flaw with `file:line` (cite from the embedded diff) and a
-            proposed fix. Mark blocking concerns explicitly with
-            **(blocking)** at the start of the bullet.
-
-            If you genuinely have nothing to say, the body may be a
-            single line.
+            ${{ env.PHASE_3_OUTPUT_FORMAT }}
 
             Critical: if you find yourself citing a file or symbol that
             isn't actually present in the embedded diff, STOP — that is


### PR DESCRIPTION
## Summary

The Gemini stdin prompt (built in the `prep` job) and the Claude `prompt:` input (in `claude-review`) carried near-verbatim copies of three substantive sections — drift-prone duplication every time the review rubric is tuned.

This change factors them into workflow-level `env:` so both reviewers reference one source of truth.

## What was extracted

- **`PHASE_3_ROLE`** — the role-statement opener (`You are an adversarial Phase 3 reviewer (MEMORY.md §II — Verified Spec-Driven Development / VSDD).`).
- **`PHASE_3_REVIEW_RULES`** — the bullet list of "Look ONLY for:" criteria (spec divergence, tautological tests, hidden coupling, multi-word symbols §IX, inconsistent error handling, spec-discipline §VII).
- **`PHASE_3_OUTPUT_FORMAT`** — the verdict frontmatter shape, verdict semantics (`pass` ⇔ APPROVE, `fail` ⇔ REQUEST_CHANGES, "pass with nitpicks is fine"), and the **(blocking)** bullet-marking rule.

Each is a multi-line `|-` scalar at workflow scope; both call sites interpolate via `${{ env.* }}`.

## What stays inline (reviewer-specific framing)

- Gemini's `"Review the PR diff below against the standards in MEMORY.md (§I–§IX). Look ONLY for:"` bridge.
- Claude's `# CRITICAL OUTPUT FORMAT (read this FIRST)` preamble and Acceptable-response example.
- Claude's anti-hallucination guard (`Critical: if you find yourself citing a file or symbol that isn't actually present in the embedded diff, STOP — that is a hallucination. Only cite what's in the embedded content.`).
- Section-separator labels (`--- MEMORY.md ---`).

## Pure refactor

No semantic change to the rules, format, or framing. The substituted prompts are equivalent to the pre-refactor versions; the only intentional differences are trivial:

- "Verified Spec-Driven Development / VSDD" replaces the two divergent expansions ("Verified Spec-Driven Development" in Gemini, "VSDD" in Claude) — same meaning.
- Bullets dropped two leading spaces (still valid markdown, identical to a model parser).
- The OUTPUT FORMAT spec converged on the more complete Gemini wording (which is a strict superset of Claude's tighter version).

## Conflict warning

The open `fix/issue-*` PRs that touch this file will need rebase after this lands:

- #17
- #18
- #19
- #20
- #22
- #24

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pulls.yml'))"` parses cleanly.
- [ ] Next PR against `main` triggers the workflow and both reviewers post a verdict comment with the same rubric.
- [ ] Diff a `gemini-stdin.txt` from a workflow run before/after this change — substantively equivalent body.