### PR TITLE
feat(promote): assignment-triggered promotion pipeline + ownership gate

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -11,6 +11,15 @@ inputs:
     description: "GitHub org whose members are allowed to invoke this agent. Non-members trigger a hard fail. Default sw2m."
     required: false
     default: "sw2m"
+  actor-override:
+    description: |
+      If set, validate this login against the org instead of the workflow
+      trigger sender. Used by callers that have already identified an
+      org-member owner via richer context (PR author + assignees, issue
+      assignees, etc.). Empty string (default) preserves the original
+      sender-based check.
+    required: false
+    default: ""
   prompt:
     description: "Optional inline prompt prepended to stdin-file before piping to claude."
     required: false
@@ -34,6 +43,21 @@ inputs:
     description: "Where claude's stdout is written. Caller reads from this path after the action runs."
     required: false
     default: "claude-output.txt"
+  allowed-tools:
+    description: |
+      Tools claude is permitted to invoke. Default `""` disables every
+      tool (pure inference). Pass e.g. `"Bash Edit Write Read"` to allow
+      filesystem and shell access for agentic phases (used by the
+      promote-tech-to-pr pipeline). Space-separated list.
+    required: false
+    default: ""
+  permission-mode:
+    description: |
+      Permission mode passed to claude. `default` (claude's default) for
+      inference; `bypassPermissions` for non-interactive autonomous runs
+      where `allowed-tools` is non-empty. Leave empty to omit the flag.
+    required: false
+    default: ""
 
 outputs:
   output-file:
@@ -47,11 +71,16 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-        ACTOR: ${{ github.event.sender.login || github.actor }}
+        SENDER: ${{ github.event.sender.login || github.actor }}
+        OVERRIDE: ${{ inputs.actor-override }}
         ORG: ${{ inputs.org }}
       run: |
         # Hard gate: agents must not be invocable by non-org-members.
         # NOTE: the default GITHUB_TOKEN can only see PUBLIC org memberships.
+        ACTOR="${OVERRIDE:-$SENDER}"
+        if [ -n "$OVERRIDE" ] && [ "$OVERRIDE" != "$SENDER" ]; then
+          echo "actor-override active: validating '$OVERRIDE' (caller-provided owner) instead of trigger sender '$SENDER'."
+        fi
         if ! gh api "orgs/$ORG/members/$ACTOR" >/dev/null 2>&1; then
           echo "::error::$ACTOR is not a (publicly-visible) member of the '$ORG' GitHub org."
           echo ""
@@ -60,7 +89,8 @@ runs:
           echo "next to your row."
           echo ""
           echo "If you are not a member: agent invocations (Claude) are"
-          echo "restricted to org members."
+          echo "restricted to org members. Self-assign on an issue or PR"
+          echo "to take ownership."
           exit 1
         fi
         echo "✓ $ACTOR is a $ORG org member (public)."
@@ -73,7 +103,7 @@ runs:
       shell: bash
       run: npm install -g @anthropic-ai/claude-code@latest
 
-    - name: Invoke claude (--print, no tools, with fallback)
+    - name: Invoke claude (--print, with fallback model on error)
       shell: bash
       env:
         ANTHROPIC_API_KEY: ${{ inputs.api-key }}
@@ -82,6 +112,8 @@ runs:
         MODEL: ${{ inputs.model }}
         FALLBACK: ${{ inputs.fallback-model }}
         OUTPUT: ${{ inputs.output-file }}
+        TOOLS: ${{ inputs.allowed-tools }}
+        PMODE: ${{ inputs.permission-mode }}
       run: |
         set -euo pipefail
         : > combined-input.txt
@@ -101,19 +133,30 @@ runs:
         fi
         echo "input bytes: $(wc -c < combined-input.txt)"
 
-        # `--print` = non-interactive single-turn; pipe stdin as the prompt.
-        # `--allowed-tools ""` disables every tool. Pure inference; we want
-        # claude to produce text, not run tools. `--permission-mode plan`
-        # was rejected earlier — plan mode produces a "what I would do"
-        # summary instead of doing it.
+        # Build the flag list. `--allowed-tools ""` (the default) is the
+        # original inference-only contract. When TOOLS is non-empty,
+        # callers (e.g. promote-tech-to-pr) get filesystem + shell access
+        # for agentic phases. `--permission-mode plan` was rejected
+        # earlier — plan mode produces a "what I would do" summary
+        # instead of doing it; promote-tech-to-pr needs `bypassPermissions`
+        # so non-interactive runs don't stall on tool prompts.
+        FLAGS=(--print --model "$MODEL" --allowed-tools "$TOOLS")
+        if [ -n "$PMODE" ]; then
+          FLAGS+=(--permission-mode "$PMODE")
+        fi
+        FALLBACK_FLAGS=(--print --model "$FALLBACK" --allowed-tools "$TOOLS")
+        if [ -n "$PMODE" ]; then
+          FALLBACK_FLAGS+=(--permission-mode "$PMODE")
+        fi
+
         set +e
-        claude --print --model "$MODEL" --allowed-tools "" < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
+        claude "${FLAGS[@]}" < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
         rc=$?
         if [ $rc -ne 0 ]; then
           echo "::warning::Primary model '$MODEL' exited $rc; falling back to '$FALLBACK'."
           echo "--- primary stderr ---"
           cat claude-stderr.log
-          claude --print --model "$FALLBACK" --allowed-tools "" < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
+          claude "${FALLBACK_FLAGS[@]}" < combined-input.txt > "$OUTPUT" 2>claude-stderr.log
           rc=$?
           if [ $rc -ne 0 ]; then
             echo "::error::Fallback model '$FALLBACK' also exited $rc."

--- a/.github/actions/gemini/action.yml
+++ b/.github/actions/gemini/action.yml
@@ -10,6 +10,16 @@ inputs:
     description: "GitHub org whose members are allowed to invoke this agent. Non-members trigger a hard fail. Default sw2m."
     required: false
     default: "sw2m"
+  actor-override:
+    description: |
+      If set, validate this login against the org instead of the workflow
+      trigger sender. Used by callers that have already identified an
+      org-member owner via richer context (PR author + assignees) — for
+      example when a fork-PR `synchronize` event's sender is the external
+      pusher but the PR is owned by an org-member assignee. Empty string
+      (default) preserves the original sender-based check.
+    required: false
+    default: ""
   prompt:
     description: "Optional inline prompt prepended to stdin-file before piping to gemini."
     required: false
@@ -46,7 +56,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-        ACTOR: ${{ github.event.sender.login || github.actor }}
+        SENDER: ${{ github.event.sender.login || github.actor }}
+        OVERRIDE: ${{ inputs.actor-override }}
         ORG: ${{ inputs.org }}
       run: |
         # Hard gate: agents must not be invocable by non-org-members.
@@ -54,6 +65,10 @@ runs:
         # Members whose membership is private are invisible to this check
         # and will trigger a hard fail. Make membership public on the org
         # page (Settings → People → "Make public") to be recognized.
+        ACTOR="${OVERRIDE:-$SENDER}"
+        if [ -n "$OVERRIDE" ] && [ "$OVERRIDE" != "$SENDER" ]; then
+          echo "actor-override active: validating '$OVERRIDE' (caller-provided owner) instead of trigger sender '$SENDER'."
+        fi
         if ! gh api "orgs/$ORG/members/$ACTOR" >/dev/null 2>&1; then
           echo "::error::$ACTOR is not a (publicly-visible) member of the '$ORG' GitHub org."
           echo ""
@@ -64,7 +79,7 @@ runs:
           echo ""
           echo "If you are not a member: agent invocations (Gemini) are"
           echo "restricted to org members. An org member must open the PR"
-          echo "on your behalf."
+          echo "on your behalf or self-assign to take ownership."
           exit 1
         fi
         echo "✓ $ACTOR is a $ORG org member (public)."

--- a/.github/actions/promote-goal-to-tech/action.yml
+++ b/.github/actions/promote-goal-to-tech/action.yml
@@ -1,0 +1,223 @@
+name: "Promote goal-spec to tech-specs"
+description: |
+  Reads a `spec:goal` issue, asks Claude to decompose it into N
+  tech-spec sub-issues (one technical problem per tech spec, per
+  MEMORY.md §VII), and opens each as a `spec:tech` issue with a
+  back-link to the parent goal. Posts a summary comment on the goal.
+
+  The agent's job is decomposition, not solution — each tech-spec body
+  describes ONE concrete technical problem and what "done" looks like,
+  but does not propose code, APIs, or implementation. Phase 3 of the
+  tech→PR pipeline is where implementation happens.
+
+inputs:
+  issue-number:
+    description: "Number of the goal-spec issue to decompose."
+    required: true
+  owner-login:
+    description: "GitHub login of the org-member assignee taking ownership."
+    required: true
+  anthropic-api-key:
+    description: "ANTHROPIC_API_KEY value."
+    required: true
+  github-token:
+    description: "Token used to read the goal issue and create tech-spec issues."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Read goal issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+      run: |
+        set -euo pipefail
+        gh issue view "$ISSUE_NUMBER" --json title,body,labels,number,url > goal.json
+        jq -r '.title' goal.json > goal-title.txt
+        jq -r '.body'  goal.json > goal-body.txt
+        echo "goal title: $(cat goal-title.txt)"
+        echo "goal body bytes: $(wc -c < goal-body.txt)"
+
+    - name: Build agent prompt
+      shell: bash
+      run: |
+        set -euo pipefail
+        cat > stdin.txt <<'PROMPT_EOF'
+        # CRITICAL OUTPUT FORMAT (read this FIRST)
+
+        Your response MUST start with YAML frontmatter on the very first
+        line — no preamble, no leading whitespace. The frontmatter has
+        exactly one key, `tech_specs`, whose value is a list. Each entry
+        has `title` and `body`. After the closing `---` you may write a
+        free-form summary; the parser ignores it.
+
+        Concrete example of an acceptable response:
+
+        ```
+        ---
+        tech_specs:
+          - title: "[tech] Add ownership-gate job to pulls.yml"
+            body: |
+              **Problem.** pulls.yml currently runs Phase 3 review on every
+              non-draft PR regardless of who opened it. External-contributor
+              PRs consume agent budget without ownership.
+
+              **Done when.** A new `ownership` job runs first; downstream
+              jobs `needs: [ownership]` and skip when no org-member author
+              or assignee is present.
+
+              **Section reference.** §I (Adversary), §II Phase 3.
+          - title: "[tech] ..."
+            body: |
+              ...
+        ---
+
+        (free-form summary may follow, ignored by the parser)
+        ```
+
+        # TASK
+
+        You are decomposing a goal-spec issue into tech-spec sub-issues
+        per MEMORY.md §VII (Spec Discipline).
+
+        Rules:
+        - One technical problem per tech-spec. No bundling. If the goal
+          has N distinct technical problems, output N tech-specs.
+        - Tech-spec bodies describe **what** is broken/missing and **what
+          "done" looks like** — not the implementation. Do NOT propose
+          code, APIs, function names, or design. Phase 3 of the tech→PR
+          pipeline does the implementation.
+        - Each tech-spec title must be self-explanatory (≤60 chars).
+        - If the goal-spec is already a single technical problem, output
+          one tech-spec.
+        - If the goal-spec is too vague to decompose, output zero
+          tech-specs and explain in the free-form summary; the human
+          will refine the goal first.
+
+        Inputs are EMBEDDED below — do not look for files on disk.
+        Cite only what is in the embedded text.
+
+        --- MEMORY.md ---
+        PROMPT_EOF
+        cat MEMORY.md >> stdin.txt
+        {
+          printf '\n--- GOAL ISSUE TITLE ---\n'
+          cat goal-title.txt
+          printf '\n--- GOAL ISSUE BODY ---\n'
+          cat goal-body.txt
+        } >> stdin.txt
+        echo "stdin.txt bytes: $(wc -c < stdin.txt)"
+
+    - name: Run Claude (org-member gate inside)
+      uses: ./.github/actions/claude
+      with:
+        api-key: ${{ inputs.anthropic-api-key }}
+        actor-override: ${{ inputs.owner-login }}
+        stdin-file: stdin.txt
+        output-file: tech-specs.md
+
+    - name: Parse tech-specs and open sub-issues
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        OWNER_LOGIN: ${{ inputs.owner-login }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import json, os, re, subprocess, sys, yaml
+
+        issue_number = os.environ['ISSUE_NUMBER']
+        owner = os.environ['OWNER_LOGIN']
+
+        with open('tech-specs.md') as f:
+            raw = f.read()
+
+        # Strict frontmatter at the very top.
+        m = re.match(r'^\s*---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$', raw)
+        fm = None
+        summary = raw.strip()
+        if m:
+            try:
+                fm = yaml.safe_load(m.group(1))
+                summary = m.group(2).strip()
+            except yaml.YAMLError as e:
+                print(f'WARN: invalid YAML frontmatter: {e}', file=sys.stderr)
+
+        # Fallback: scan for an embedded ---tech_specs:---block.
+        if not isinstance(fm, dict) or 'tech_specs' not in fm:
+            m2 = re.search(r'\n---\s*\n(tech_specs\s*:[\s\S]*?)\n---\s*\n', raw)
+            if m2:
+                try:
+                    fm = yaml.safe_load(m2.group(1))
+                except yaml.YAMLError:
+                    fm = None
+
+        if not isinstance(fm, dict) or not isinstance(fm.get('tech_specs'), list):
+            print('::error::Could not extract `tech_specs` list from agent output.', file=sys.stderr)
+            print('--- raw ---', file=sys.stderr); print(raw, file=sys.stderr)
+            sys.exit(1)
+
+        opened = []
+        for spec in fm['tech_specs']:
+            if not isinstance(spec, dict) or 'title' not in spec or 'body' not in spec:
+                print(f'  skip malformed: {spec!r}'); continue
+            title = str(spec['title']).strip()
+            body = str(spec['body']).strip()
+            footer = (
+                f'\n\n---\n'
+                f'_Tech-spec sub-issue of #{issue_number} (goal). Opened by '
+                f'`promote-goal-to-tech` after @{owner} self-assigned the goal._\n'
+                f'_Assign yourself to this issue to start the 5-phase tech→PR pipeline._\n'
+            )
+            r = subprocess.run(
+                ['gh', 'issue', 'create',
+                 '--title', title,
+                 '--body', body + footer,
+                 '--label', 'spec:tech'],
+                capture_output=True, text=True,
+            )
+            if r.returncode != 0:
+                # Label may be missing on a downstream repo. Retry without.
+                r = subprocess.run(
+                    ['gh', 'issue', 'create', '--title', title, '--body', body + footer],
+                    capture_output=True, text=True, check=True,
+                )
+            url = r.stdout.strip().splitlines()[-1]
+            print(f'  opened: {url}')
+            opened.append((title, url))
+
+        # Comment on the parent goal with the list of children.
+        if opened:
+            lines = [
+                f'**Goal decomposed into {len(opened)} tech-spec sub-issue(s).**',
+                f'_Triggered by @{owner} self-assigning this goal._',
+                '',
+            ]
+            for title, url in opened:
+                lines.append(f'- {url} — {title}')
+            lines += [
+                '',
+                'Each sub-issue carries `spec:tech`. Assign yourself to a '
+                'tech-spec to start the 5-phase implementation pipeline '
+                '(scaffold → tests → Red gate → implement → Green gate).',
+            ]
+        else:
+            lines = [
+                f'**No tech-specs produced.**',
+                f'_Triggered by @{owner} but the agent could not decompose this goal._',
+                '',
+                f'Free-form rationale from the agent:',
+                '',
+                f'> {summary[:1500]}',
+                '',
+                'Refine the goal-spec body and re-assign to retry, or '
+                'open tech-specs by hand and apply `spec:tech`.',
+            ]
+        subprocess.run(
+            ['gh', 'issue', 'comment', issue_number, '--body', '\n'.join(lines)],
+            check=True,
+        )
+        PY

--- a/.github/actions/promote-tech-to-pr/action.yml
+++ b/.github/actions/promote-tech-to-pr/action.yml
@@ -1,0 +1,636 @@
+name: "Promote tech-spec to draft PR (5-phase pipeline)"
+description: |
+  Implements a tech-spec issue end-to-end via a 5-phase pipeline mapped
+  to MEMORY.md §VIII (Regression Sets and the 4-Result Rule):
+
+    Phase 1 — Scaffold     (CI: branch + draft PR with spec embedded)
+    Phase 2 — Author tests (agent writes new tests, declares regression set)
+    Phase 3 — Red gate     (CI runs tests, expects new=red + regression=green)
+                            mismatch → loop to Phase 2 (max 3 retries)
+    Phase 4 — Implement    (agent writes code)
+    Phase 5 — Green gate   (CI runs tests, expects new=green + regression=green)
+                            mismatch → loop to Phase 4 (max 3 retries)
+
+  On exhaustion of either retry budget the action labels the issue
+  `needs-human` and comments with the last test output. The PR stays
+  draft — a human takes over from there.
+
+  Repos with no detectable test runner (docs repos, e.g. sw2m/philosophies)
+  follow the §VIII N/A path: Phases 2/3/5 are skipped and Phase 4 runs
+  once. The draft PR is the artifact for human review.
+
+inputs:
+  issue-number:
+    description: "Tech-spec issue to implement."
+    required: true
+  owner-login:
+    description: "Org-member login that took ownership by self-assigning."
+    required: true
+  anthropic-api-key:
+    description: "ANTHROPIC_API_KEY value."
+    required: true
+  github-token:
+    description: "Token used to read/edit the issue, push branch, open PR."
+    required: true
+  base-branch:
+    description: "Branch to fork the implementation branch from."
+    required: false
+    default: "main"
+  max-retries:
+    description: "Max retries per gate (Red, Green). 3 = up to 4 attempts each."
+    required: false
+    default: "3"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify org membership of the owner
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ORG: sw2m
+        OWNER: ${{ inputs.owner-login }}
+      run: |
+        if ! gh api "orgs/$ORG/members/$OWNER" >/dev/null 2>&1; then
+          echo "::error::owner-login '$OWNER' is not a public sw2m member; refusing to run."
+          exit 1
+        fi
+        echo "✓ owner $OWNER is a $ORG org member."
+
+    - name: Read tech-spec issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+      run: |
+        set -euo pipefail
+        gh issue view "$ISSUE_NUMBER" --json title,body,number,url > tech.json
+        jq -r '.title' tech.json > tech-title.txt
+        jq -r '.body'  tech.json > tech-body.txt
+        jq -r '.url'   tech.json > tech-url.txt
+        echo "tech-spec: $(cat tech-title.txt)"
+
+    - name: Detect test runner
+      id: runner
+      shell: bash
+      run: |
+        set -euo pipefail
+        # First match wins. The detected default command is a hint to the
+        # agent in Phase 2; the agent may override with a more specific
+        # command in its frontmatter output.
+        CMD=""
+        if [ -f Makefile ] && grep -qE '^test:' Makefile; then
+          CMD="make test"
+        elif [ -f package.json ] && jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+          if [ -f bun.lockb ] || [ -f bun.lock ]; then CMD="bun test"; else CMD="npm test"; fi
+        elif [ -f deno.json ] || [ -f deno.jsonc ]; then
+          CMD="deno test -A"
+        elif [ -f pyproject.toml ] || [ -f pytest.ini ] || [ -f setup.py ]; then
+          CMD="pytest"
+        elif [ -f Cargo.toml ]; then
+          CMD="cargo test"
+        elif [ -f go.mod ]; then
+          CMD="go test ./..."
+        fi
+        echo "default-cmd=$CMD" >> "$GITHUB_OUTPUT"
+        if [ -z "$CMD" ]; then
+          echo "no-runner=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::No test runner detected. §VIII (4-Result Rule) is N/A; Phases 2/3/5 will be skipped."
+        else
+          echo "no-runner=false" >> "$GITHUB_OUTPUT"
+          echo "Detected test command: $CMD"
+        fi
+
+    - name: Configure git
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        git config user.name  "promote-tech-to-pr[bot]"
+        git config user.email "promote-tech-to-pr@users.noreply.github.com"
+
+    - name: Phase 1 — Scaffold (branch + draft PR)
+      id: scaffold
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        OWNER_LOGIN: ${{ inputs.owner-login }}
+        BASE_BRANCH: ${{ inputs.base-branch }}
+      run: |
+        set -euo pipefail
+        BRANCH="feat/issue-$ISSUE_NUMBER-promote"
+        # Idempotent: if the branch already exists upstream from a prior
+        # run, check it out instead of creating fresh. Half-implemented
+        # state from an interrupted run is still useful context for the
+        # agent.
+        git fetch origin "$BASE_BRANCH"
+        if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          echo "Branch $BRANCH already existed; resuming."
+        else
+          git checkout -b "$BRANCH" "origin/$BASE_BRANCH"
+          # Make a no-op commit so the branch can be pushed and a PR opened.
+          # The actual implementation lands in subsequent phases.
+          mkdir -p .vsdd
+          {
+            echo "Promotion run for issue #$ISSUE_NUMBER"
+            echo "Owner: @$OWNER_LOGIN"
+            echo "Started: $(date -u +%FT%TZ)"
+          } > .vsdd/promotion-$ISSUE_NUMBER.log
+          git add .vsdd/promotion-$ISSUE_NUMBER.log
+          git commit -m "chore(promote): scaffold for #$ISSUE_NUMBER"
+          git push -u origin "$BRANCH"
+        fi
+        echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+        # Open or reuse the draft PR.
+        EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+        if [ -n "$EXISTING_PR" ]; then
+          echo "pr-number=$EXISTING_PR" >> "$GITHUB_OUTPUT"
+          echo "Reusing existing PR #$EXISTING_PR for branch $BRANCH"
+        else
+          TITLE=$(cat tech-title.txt)
+          BODY_FILE=$(mktemp)
+          {
+            echo "Closes #$ISSUE_NUMBER"
+            echo ""
+            echo "_Draft PR scaffolded by \`promote-tech-to-pr\` after @$OWNER_LOGIN"
+            echo "self-assigned the tech-spec. The 5-phase pipeline (Phase 1 scaffold →"
+            echo "Phase 2 author tests → Phase 3 Red gate → Phase 4 implement → Phase 5"
+            echo "Green gate) drives this PR to completion or bails with \`needs-human\`._"
+            echo ""
+            echo "## Embedded tech-spec"
+            echo ""
+            cat tech-body.txt
+          } > "$BODY_FILE"
+          PR_URL=$(gh pr create --draft --base "$BASE_BRANCH" --head "$BRANCH" --title "$TITLE" --body-file "$BODY_FILE")
+          PR_NUMBER=$(basename "$PR_URL")
+          echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Opened draft PR #$PR_NUMBER: $PR_URL"
+        fi
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: "20"
+
+    - name: Install Claude Code CLI
+      shell: bash
+      run: npm install -g @anthropic-ai/claude-code@latest
+
+    - name: Phases 2-3 — Author tests + Red gate (with retry)
+      id: red-gate
+      if: ${{ steps.runner.outputs.no-runner == 'false' }}
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        BRANCH: ${{ steps.scaffold.outputs.branch }}
+        PR_NUMBER: ${{ steps.scaffold.outputs.pr-number }}
+        DEFAULT_TEST_CMD: ${{ steps.runner.outputs.default-cmd }}
+        MAX_RETRIES: ${{ inputs.max-retries }}
+      run: |
+        set -euo pipefail
+
+        invoke_claude() {
+          local input="$1" output="$2"
+          local primary="claude-opus-4-5" fallback="claude-sonnet-4-5"
+          set +e
+          claude --print --model "$primary" \
+            --allowed-tools "Bash Edit Write Read Glob Grep" \
+            --permission-mode bypassPermissions \
+            < "$input" > "$output" 2>claude-err.log
+          local rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "::warning::Phase agent: primary $primary exited $rc; falling back to $fallback"
+            tail -50 claude-err.log
+            claude --print --model "$fallback" \
+              --allowed-tools "Bash Edit Write Read Glob Grep" \
+              --permission-mode bypassPermissions \
+              < "$input" > "$output" 2>claude-err.log
+            rc=$?
+          fi
+          set -e
+          return $rc
+        }
+
+        ATTEMPTS=$((MAX_RETRIES + 1))
+        attempt=0
+        red_gate_passed=false
+        last_failure=""
+
+        while [ $attempt -lt $ATTEMPTS ]; do
+          attempt=$((attempt + 1))
+          echo ""
+          echo "=== Phase 2 — Author tests (attempt $attempt of $ATTEMPTS) ==="
+
+          PHASE2_INPUT=$(mktemp)
+          {
+            cat <<'PROMPT_EOF'
+        # CRITICAL OUTPUT FORMAT (read FIRST)
+
+        At the END of your response, after you have used your tools to write
+        the test files, output a YAML frontmatter block summarizing what you
+        did. The block must be the LAST thing in your response, delimited
+        by `---` lines:
+
+        ---
+        new_test_files:
+          - path/to/new_test_file_1.ext
+          - path/to/new_test_file_2.ext
+        new_test_command: "exact command to run ONLY the new tests"
+        regression_test_command: "exact command to run ONLY the pre-existing tests"
+        ---
+
+        Both commands must exit 0 on pass, non-zero on fail. They will be
+        run from the repo root. They are how Phase 3 (Red Gate) and Phase 5
+        (Green Gate) classify results.
+
+        # TASK
+
+        You are running Phase 2 of the VSDD tech-to-PR pipeline. Read
+        MEMORY.md §VIII (4-Result Rule) for context. Your job:
+
+        1. Read the embedded tech-spec issue.
+        2. Identify the regression set: pre-existing tests in this repo
+           that exercise the blast radius of the change. Do NOT modify
+           those — they are the regression set.
+        3. Write NEW test files for the tech-spec. The new tests must
+           FAIL right now (no implementation yet — that's Phase 4) and
+           must be non-tautological (they would fail even if you wrote a
+           naive wrong implementation).
+        4. Use your tools (Write, Edit, Bash) to create the new test
+           files in this repo. Do not commit — Phase 3 commits if Red
+           passes.
+        5. Output the frontmatter block at the END of your response.
+
+        Constraints:
+        - One technical problem per tech-spec (per §VII). If the issue
+          covers more than one, STOP and write a single-line frontmatter
+          with empty `new_test_files` and a comment in the response body
+          explaining why; the pipeline will bail.
+        - The default test command detected for this repo is in env var
+          DEFAULT_TEST_CMD; you may use it as a hint but must produce the
+          two specific commands above.
+
+        ---
+        PROMPT_EOF
+            printf 'DEFAULT_TEST_CMD=%s\n\n' "$DEFAULT_TEST_CMD"
+            printf -- '--- MEMORY.md ---\n'
+            cat MEMORY.md
+            printf '\n--- TECH-SPEC ISSUE TITLE ---\n'
+            cat tech-title.txt
+            printf '\n--- TECH-SPEC ISSUE BODY ---\n'
+            cat tech-body.txt
+          } > "$PHASE2_INPUT"
+
+          PHASE2_OUTPUT=$(mktemp)
+          if ! invoke_claude "$PHASE2_INPUT" "$PHASE2_OUTPUT"; then
+            last_failure="Phase 2 agent (attempt $attempt) exited non-zero on both primary and fallback models."
+            echo "::warning::$last_failure"
+            tail -50 claude-err.log || true
+            continue
+          fi
+
+          # Extract the frontmatter from the END of the agent output.
+          # The parser writes phase2-meta.json and prints declared files.
+          NEW_FILES=$(python3 .github/scripts/parse-phase2-frontmatter.py "$PHASE2_OUTPUT" 2>phase2-parse-err.log) || {
+            last_failure="Phase 2 frontmatter parse failed (attempt $attempt). $(cat phase2-parse-err.log)"
+            echo "::warning::$last_failure"
+            continue
+          }
+
+          NEW_CMD=$(jq -r '.new_cmd' phase2-meta.json)
+          REG_CMD=$(jq -r '.reg_cmd' phase2-meta.json)
+
+          if [ -z "$NEW_CMD" ] || [ -z "$REG_CMD" ] || [ -z "$NEW_FILES" ]; then
+            last_failure="Phase 2 declared empty new_test_files / new_cmd / reg_cmd (attempt $attempt). The agent did not produce a usable test set."
+            echo "::warning::$last_failure"
+            continue
+          fi
+
+          echo "Phase 2 declared new test files:"; echo "$NEW_FILES"
+          echo "Phase 2 new test command: $NEW_CMD"
+          echo "Phase 2 regression test command: $REG_CMD"
+
+          echo ""
+          echo "=== Phase 3 — Red gate (attempt $attempt) ==="
+          set +e
+          eval "$NEW_CMD" >red-new.log 2>&1
+          NEW_RC=$?
+          eval "$REG_CMD" >red-reg.log 2>&1
+          REG_RC=$?
+          set -e
+
+          echo "  new tests exit: $NEW_RC (expect non-zero)"
+          echo "  regression tests exit: $REG_RC (expect zero)"
+
+          if [ $NEW_RC -ne 0 ] && [ $REG_RC -eq 0 ]; then
+            echo "✓ Red gate passed."
+            red_gate_passed=true
+            git add .
+            if ! git diff --cached --quiet; then
+              git commit -m "test(promote): Phase 2 — author tests for #$ISSUE_NUMBER"
+              git push origin "$BRANCH"
+            fi
+            break
+          fi
+
+          if [ $NEW_RC -eq 0 ]; then
+            last_failure="Red gate FAIL: new tests passed before implementation (likely tautological tests). attempt $attempt of $ATTEMPTS."
+          elif [ $REG_RC -ne 0 ]; then
+            last_failure="Red gate FAIL: regression tests broken by Phase 2 changes. attempt $attempt of $ATTEMPTS."
+          fi
+          echo "::warning::$last_failure"
+          # Reset Phase 2 changes before retry — start clean each attempt.
+          git checkout -- .
+          git clean -fd
+        done
+
+        if [ "$red_gate_passed" != "true" ]; then
+          echo "::error::Red gate exhausted retries. Last failure: $last_failure"
+          {
+            echo "$last_failure"
+            echo ""
+            echo "Last new-tests output:"
+            echo '```'
+            tail -100 red-new.log 2>/dev/null || true
+            echo '```'
+            echo ""
+            echo "Last regression-tests output:"
+            echo '```'
+            tail -100 red-reg.log 2>/dev/null || true
+            echo '```'
+          } > red-bail.md
+          echo "bailed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "bailed=false" >> "$GITHUB_OUTPUT"
+          # Persist the test commands for Phase 5.
+          cp phase2-meta.json phase2-meta-final.json
+        fi
+
+    - name: Bail on Red-gate exhaustion
+      if: ${{ steps.runner.outputs.no-runner == 'false' && steps.red-gate.outputs.bailed == 'true' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        PR_NUMBER: ${{ steps.scaffold.outputs.pr-number }}
+        OWNER_LOGIN: ${{ inputs.owner-login }}
+      run: |
+        set -euo pipefail
+        gh issue edit "$ISSUE_NUMBER" --add-label needs-human || true
+        BODY=$(mktemp)
+        {
+          echo "**Promote-tech-to-pr bailed at Red gate (Phase 3).**"
+          echo ""
+          echo "_The agent exhausted its retry budget trying to write tests"
+          echo "that fail before implementation while keeping the regression"
+          echo "set green. This usually means: the tech-spec covers more"
+          echo "than one technical problem (§VII violation), or the change"
+          echo "interacts with the regression set in a way the agent can't"
+          echo "isolate._"
+          echo ""
+          cat red-bail.md
+          echo ""
+          echo "@$OWNER_LOGIN — over to you. Inspect the draft PR (#$PR_NUMBER), "
+          echo "either refine the tech-spec into smaller pieces or take over"
+          echo "the implementation by hand."
+        } > "$BODY"
+        gh issue comment "$ISSUE_NUMBER" --body-file "$BODY"
+        gh pr comment "$PR_NUMBER" --body-file "$BODY"
+        echo "::error::Red gate bailed; needs-human label applied."
+        exit 1
+
+    - name: Phases 4-5 — Implement + Green gate (with retry)
+      id: green-gate
+      if: ${{ steps.red-gate.outputs.bailed != 'true' }}
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        BRANCH: ${{ steps.scaffold.outputs.branch }}
+        PR_NUMBER: ${{ steps.scaffold.outputs.pr-number }}
+        NO_RUNNER: ${{ steps.runner.outputs.no-runner }}
+        MAX_RETRIES: ${{ inputs.max-retries }}
+      run: |
+        set -euo pipefail
+
+        invoke_claude() {
+          local input="$1" output="$2"
+          local primary="claude-opus-4-5" fallback="claude-sonnet-4-5"
+          set +e
+          claude --print --model "$primary" \
+            --allowed-tools "Bash Edit Write Read Glob Grep" \
+            --permission-mode bypassPermissions \
+            < "$input" > "$output" 2>claude-err.log
+          local rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "::warning::Phase agent: primary $primary exited $rc; falling back to $fallback"
+            tail -50 claude-err.log
+            claude --print --model "$fallback" \
+              --allowed-tools "Bash Edit Write Read Glob Grep" \
+              --permission-mode bypassPermissions \
+              < "$input" > "$output" 2>claude-err.log
+            rc=$?
+          fi
+          set -e
+          return $rc
+        }
+
+        if [ "$NO_RUNNER" = "true" ]; then
+          ATTEMPTS=1
+          NEW_CMD=""
+          REG_CMD=""
+        else
+          ATTEMPTS=$((MAX_RETRIES + 1))
+          NEW_CMD=$(jq -r '.new_cmd' phase2-meta-final.json)
+          REG_CMD=$(jq -r '.reg_cmd' phase2-meta-final.json)
+        fi
+
+        attempt=0
+        green_gate_passed=false
+        last_failure=""
+
+        while [ $attempt -lt $ATTEMPTS ]; do
+          attempt=$((attempt + 1))
+          echo ""
+          echo "=== Phase 4 — Implement (attempt $attempt of $ATTEMPTS) ==="
+
+          PHASE4_INPUT=$(mktemp)
+          {
+            cat <<'PROMPT_EOF'
+        # TASK
+
+        You are running Phase 4 of the VSDD tech-to-PR pipeline. The tests
+        from Phase 2 are committed and failing (Red gate). Your job:
+
+        1. Read the embedded tech-spec issue.
+        2. Implement the spec using your tools (Write, Edit, Bash, Read).
+        3. Do NOT modify the test files — the tests are the spec made
+           executable; modifying them is cheating. If a test is genuinely
+           wrong, comment about it in your response and the pipeline will
+           bail to a human.
+        4. Make the new tests pass without breaking the regression set.
+        5. Be minimal — only write the code that makes the tests pass.
+           Avoid scope creep, refactors, or speculative abstractions.
+
+        Inputs are EMBEDDED below. Do not look for files on disk you did
+        not check out.
+
+        ---
+        PROMPT_EOF
+            printf -- '--- MEMORY.md ---\n'
+            cat MEMORY.md
+            printf '\n--- TECH-SPEC ISSUE TITLE ---\n'
+            cat tech-title.txt
+            printf '\n--- TECH-SPEC ISSUE BODY ---\n'
+            cat tech-body.txt
+            if [ "$NO_RUNNER" != "true" ]; then
+              printf '\n--- TEST RUN COMMANDS ---\n'
+              printf 'New tests command (must end up exit 0): %s\n' "$NEW_CMD"
+              printf 'Regression tests command (must end up exit 0): %s\n' "$REG_CMD"
+            fi
+          } > "$PHASE4_INPUT"
+
+          PHASE4_OUTPUT=$(mktemp)
+          if ! invoke_claude "$PHASE4_INPUT" "$PHASE4_OUTPUT"; then
+            last_failure="Phase 4 agent (attempt $attempt) exited non-zero on both primary and fallback models."
+            echo "::warning::$last_failure"
+            tail -50 claude-err.log || true
+            git checkout -- . && git clean -fd
+            continue
+          fi
+
+          if [ "$NO_RUNNER" = "true" ]; then
+            # No tests to run; agent's tool changes are the artifact.
+            echo "No test runner — committing Phase 4 changes as final."
+            git add .
+            if git diff --cached --quiet; then
+              last_failure="Phase 4 produced no changes (no-runner path)."
+              echo "::warning::$last_failure"
+            else
+              git commit -m "feat(promote): Phase 4 implementation for #$ISSUE_NUMBER"
+              git push origin "$BRANCH"
+              green_gate_passed=true
+            fi
+            break
+          fi
+
+          echo ""
+          echo "=== Phase 5 — Green gate (attempt $attempt) ==="
+          set +e
+          eval "$NEW_CMD" >green-new.log 2>&1
+          NEW_RC=$?
+          eval "$REG_CMD" >green-reg.log 2>&1
+          REG_RC=$?
+          set -e
+
+          echo "  new tests exit: $NEW_RC (expect zero)"
+          echo "  regression tests exit: $REG_RC (expect zero)"
+
+          if [ $NEW_RC -eq 0 ] && [ $REG_RC -eq 0 ]; then
+            echo "✓ Green gate passed."
+            green_gate_passed=true
+            git add .
+            if ! git diff --cached --quiet; then
+              git commit -m "feat(promote): Phase 4 implementation for #$ISSUE_NUMBER"
+              git push origin "$BRANCH"
+            fi
+            break
+          fi
+
+          if [ $NEW_RC -ne 0 ]; then
+            last_failure="Green gate FAIL: new tests still failing — implementation incomplete. attempt $attempt of $ATTEMPTS."
+          elif [ $REG_RC -ne 0 ]; then
+            last_failure="Green gate FAIL: regression broken by implementation. attempt $attempt of $ATTEMPTS."
+          fi
+          echo "::warning::$last_failure"
+          # Reset Phase 4 changes before retry — keep Phase 2 tests
+          # (already committed in last Red-gate-pass) but throw away the
+          # bad implementation attempt. Stash and drop.
+          git stash --include-untracked || true
+          git stash drop || true
+        done
+
+        if [ "$green_gate_passed" != "true" ]; then
+          echo "::error::Green gate exhausted retries. Last failure: $last_failure"
+          {
+            echo "$last_failure"
+            echo ""
+            if [ "$NO_RUNNER" != "true" ]; then
+              echo "Last new-tests output:"; echo '```'
+              tail -100 green-new.log 2>/dev/null || true; echo '```'
+              echo ""
+              echo "Last regression-tests output:"; echo '```'
+              tail -100 green-reg.log 2>/dev/null || true; echo '```'
+            fi
+          } > green-bail.md
+          echo "bailed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "bailed=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Bail on Green-gate exhaustion
+      if: ${{ steps.green-gate.outputs.bailed == 'true' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        PR_NUMBER: ${{ steps.scaffold.outputs.pr-number }}
+        OWNER_LOGIN: ${{ inputs.owner-login }}
+      run: |
+        set -euo pipefail
+        gh issue edit "$ISSUE_NUMBER" --add-label needs-human || true
+        BODY=$(mktemp)
+        {
+          echo "**Promote-tech-to-pr bailed at Green gate (Phase 5).**"
+          echo ""
+          echo "_The implementation either could not pass the new tests"
+          echo "or broke regressions, even after the retry budget. Tests"
+          echo "(from Phase 2) are committed on the branch; the failed"
+          echo "Phase 4 implementation attempts have been discarded._"
+          echo ""
+          cat green-bail.md
+          echo ""
+          echo "@$OWNER_LOGIN — over to you. Either implement by hand on"
+          echo "branch \`${BRANCH:-the PR branch}\`, or refine the tech-spec"
+          echo "and re-trigger by re-assigning yourself."
+        } > "$BODY"
+        gh issue comment "$ISSUE_NUMBER" --body-file "$BODY"
+        gh pr comment "$PR_NUMBER" --body-file "$BODY"
+        echo "::error::Green gate bailed; needs-human label applied."
+        exit 1
+
+    - name: Final summary comment on success
+      if: ${{ steps.green-gate.outputs.bailed == 'false' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        PR_NUMBER: ${{ steps.scaffold.outputs.pr-number }}
+        OWNER_LOGIN: ${{ inputs.owner-login }}
+        NO_RUNNER: ${{ steps.runner.outputs.no-runner }}
+      run: |
+        set -euo pipefail
+        BODY=$(mktemp)
+        if [ "$NO_RUNNER" = "true" ]; then
+          echo "**Promote-tech-to-pr completed (no-runner path).**" > "$BODY"
+          echo ""                                                  >> "$BODY"
+          echo "_§VIII (4-Result Rule) is N/A on this repo (no test runner detected)._" >> "$BODY"
+          echo "_Phase 4 implementation is committed on the draft PR._"  >> "$BODY"
+        else
+          echo "**Promote-tech-to-pr completed (5-phase path).**"  > "$BODY"
+          echo ""                                                  >> "$BODY"
+          echo "_Red gate ✓ &nbsp;·&nbsp; Green gate ✓_"            >> "$BODY"
+          echo "_4 results across 2 runs satisfied per §VIII._"     >> "$BODY"
+        fi
+        echo ""                                                    >> "$BODY"
+        echo "Draft PR: #$PR_NUMBER. Promoting from draft to ready" >> "$BODY"
+        echo "is a human decision — Phase 3 adversarial review (pulls.yml)" >> "$BODY"
+        echo "runs after promotion."                                >> "$BODY"
+        gh pr comment "$PR_NUMBER" --body-file "$BODY"
+        gh issue comment "$ISSUE_NUMBER" --body-file "$BODY"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,22 @@
+# Labels managed by `.github/workflows/labels.yml`. Re-run that workflow
+# manually (workflow_dispatch) after editing this file — push-on-main is
+# wired but only for the philosophies repo itself.
+#
+# Color palette: green = positive/goal, blue = technical/scoped,
+# yellow = attention-needed, gray = provenance/meta.
+
+- name: "spec:goal"
+  color: "0e8a16"  # green
+  description: "Goal-spec issue. Carries breadth (many goals), no implementation detail. Assignment to an org member triggers goal→tech promotion."
+
+- name: "spec:tech"
+  color: "1d76db"  # blue
+  description: "Tech-spec issue. Covers exactly one technical problem. Assignment to an org member triggers tech→PR promotion (5-phase pipeline)."
+
+- name: "needs-human"
+  color: "fbca04"  # yellow
+  description: "Promotion pipeline bailed (Red gate or Green gate exhausted retries). Human intervention required."
+
+- name: "ci-meta"
+  color: "5319e7"  # purple
+  description: "Issue opened by VSDD CI meta-review consensus. Tracks a CI gap against MEMORY.md."

--- a/.github/scripts/parse-phase2-frontmatter.py
+++ b/.github/scripts/parse-phase2-frontmatter.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Parse Phase 2 agent output frontmatter (promote-tech-to-pr).
+
+Reads the Phase 2 output file from `sys.argv[1]`, extracts the YAML
+frontmatter block at the END of the response (the agent appends it
+after using its tools), and writes:
+
+  - phase2-meta.json — {"files": [...], "new_cmd": "...", "reg_cmd": "..."}
+  - prints each file path on stdout, one per line (so the bash caller
+    can iterate or verify non-emptiness)
+
+Exits 0 on success, non-zero with a message on stderr otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+import yaml
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print('usage: parse-phase2-frontmatter.py <phase2-output-file>', file=sys.stderr)
+        return 2
+    path = sys.argv[1]
+    with open(path) as f:
+        raw = f.read()
+
+    # Frontmatter is at the END of the response, not the start — the
+    # agent uses its tools first, summarizes after. Find ALL `--- ... ---`
+    # blocks and take the LAST one.
+    matches = list(re.finditer(r'\n---\s*\n([\s\S]*?)\n---\s*(?:\n|$)', raw))
+    if not matches:
+        print('no frontmatter block found at end of agent output', file=sys.stderr)
+        return 1
+
+    fm = yaml.safe_load(matches[-1].group(1)) or {}
+    if not isinstance(fm, dict):
+        print(f'frontmatter parsed to {type(fm).__name__}, not a dict', file=sys.stderr)
+        return 1
+
+    files = fm.get('new_test_files') or []
+    new_cmd = fm.get('new_test_command') or ''
+    reg_cmd = fm.get('regression_test_command') or ''
+    if not isinstance(files, list):
+        print('new_test_files is not a list', file=sys.stderr)
+        return 1
+
+    with open('phase2-meta.json', 'w') as f:
+        json.dump({'files': files, 'new_cmd': new_cmd, 'reg_cmd': reg_cmd}, f)
+
+    for p in files:
+        print(p)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -149,7 +149,15 @@ jobs:
             gaps:
               - title: "[ci-meta] short description (≤60 chars)"
                 body: |
-                  detailed explanation with VSDD section reference and concrete remediation
+                  Goal-spec form. Describe the problem only — what's missing,
+                  what's broken, what symptom is observed, which §-reference
+                  the gap maps to. Concrete technical detail is welcome ONLY
+                  insofar as it characterizes the problem ("Phase 2a is
+                  unenforced because no workflow runs tests with new tests
+                  expected to fail").
+                  Do NOT propose a solution, fix, or implementation path.
+                  Solutions belong in tech-spec sub-issues, opened by the
+                  promotion pipeline once an org member assigns themselves.
               - title: "..."
                 body: |
                   ...
@@ -289,7 +297,13 @@ jobs:
             gaps:
               - title: "[ci-meta] short description ≤60 chars"
                 body: |
-                  detailed explanation with VSDD section reference and concrete remediation
+                  Goal-spec form. Describe the problem only — what's missing,
+                  what's broken, what symptom is observed, which §-reference
+                  the gap maps to. Concrete technical detail is welcome ONLY
+                  insofar as it characterizes the problem.
+                  Do NOT propose a solution, fix, or implementation path.
+                  Solutions belong in tech-spec sub-issues, opened by the
+                  promotion pipeline once an org member assigns themselves.
               - title: "..."
                 body: |
                   ...
@@ -446,11 +460,19 @@ jobs:
               if any(item['title'] == g['title'] for item in existing):
                   print(f"  skip (already open): {g['title']}")
                   continue
+              # `spec:goal` enables the assignment-triggered promotion
+              # pipeline (promote.yml). When an org member self-assigns
+              # this issue, promote-goal-to-tech decomposes it into
+              # tech-spec sub-issues. `ci-meta` is provenance only.
               r = subprocess.run(
-                  ['gh', 'issue', 'create', '--title', g['title'], '--body', body, '--label', 'ci-meta'],
+                  ['gh', 'issue', 'create', '--title', g['title'], '--body', body,
+                   '--label', 'ci-meta', '--label', 'spec:goal'],
                   capture_output=True, text=True,
               )
               if r.returncode != 0:
+                  # Labels may not exist yet on first run of this workflow
+                  # in a downstream repo. Fall back to label-less creation
+                  # so a missing label doesn't block tracking the gap.
                   r = subprocess.run(
                       ['gh', 'issue', 'create', '--title', g['title'], '--body', body],
                       capture_output=True, text=True, check=True,

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,9 @@ name: VSDD Issue Review (Phase 1c)
 
 on:
   issues:
-    types: [opened, edited]
+    # `assigned` so externally-authored or bot-authored issues become
+    # eligible for Phase 1c review when an org member self-assigns.
+    types: [opened, edited, assigned]
   workflow_call:
     secrets:
       GEMINI_API_KEY:
@@ -18,8 +20,52 @@ permissions:
   contents: read
 
 jobs:
+  ownership:
+    name: Verify org-member ownership
+    runs-on: ubuntu-latest
+    outputs:
+      owned: ${{ steps.check.outputs.owned }}
+      owner: ${{ steps.check.outputs.owner }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ORG: sw2m
+          AUTHOR: ${{ github.event.issue.user.login }}
+          ASSIGNEES_JSON: ${{ toJson(github.event.issue.assignees) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          check_member() {
+            local login="$1"
+            [ -n "$login" ] && gh api "orgs/$ORG/members/$login" >/dev/null 2>&1
+          }
+          OWNER=""
+          if check_member "$AUTHOR"; then
+            OWNER="$AUTHOR"
+            echo "Owner: $AUTHOR (issue author, org member)"
+          else
+            for login in $(jq -r '.[].login' <<< "$ASSIGNEES_JSON"); do
+              if check_member "$login"; then
+                OWNER="$login"
+                echo "Owner: $login (assignee, org member)"
+                break
+              fi
+            done
+          fi
+          if [ -n "$OWNER" ]; then
+            echo "owned=true"  >> "$GITHUB_OUTPUT"
+            echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+          else
+            echo "owned=false" >> "$GITHUB_OUTPUT"
+            echo "owner="      >> "$GITHUB_OUTPUT"
+            echo "::notice::Issue not owned: author '$AUTHOR' is not an sw2m org member and no assignee is. Phase 1c review skipped. To enable, an org member must self-assign."
+          fi
+
   vsdd-issue-review:
     name: Gemini VSDD Phase 1c review
+    needs: [ownership]
+    if: ${{ needs.ownership.outputs.owned == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -76,6 +122,10 @@ jobs:
           api-key: ${{ secrets.GEMINI_API_KEY }}
           stdin-file: /tmp/vsdd/stdin.txt
           output-file: /tmp/vsdd/review.md
+          # Validate against the issue's owner (author or org-member assignee)
+          # rather than the trigger sender — an `edited` event from any user
+          # would otherwise gate on the editor, not the owner.
+          actor-override: ${{ needs.ownership.outputs.owner }}
 
       - name: Post review as issue comment
         uses: actions/github-script@v9

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,66 @@
+name: Sync labels
+
+# Idempotent label sync. Reads `.github/labels.yml` (a list of
+# {name, color, description}) and ensures each label exists with the
+# specified color/description. Safe to re-run.
+#
+# Triggered on:
+#   - push to main when `.github/labels.yml` changes
+#   - manual `workflow_dispatch` (for repo bootstrap)
+#
+# Labels managed here:
+#   - spec:goal     — issue is a goal-spec; eligible for goal→tech promotion
+#   - spec:tech     — issue is a tech-spec; eligible for tech→PR promotion
+#   - needs-human   — promote-tech-to-pr bailed; human must take over
+#   - ci-meta       — issue was opened by ci-meta consensus (provenance)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/labels.yml"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Sync labels via gh CLI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f .github/labels.yml ]; then
+            echo "::error::.github/labels.yml not found"
+            exit 1
+          fi
+          # Parse the YAML and create/update each label. `gh label create`
+          # with `--force` updates if the label already exists, which is
+          # the idempotent contract we want.
+          python3 - <<'PY'
+          import subprocess, sys, yaml
+          with open('.github/labels.yml') as f:
+              labels = yaml.safe_load(f)
+          if not isinstance(labels, list):
+              print('::error::.github/labels.yml must be a list of {name,color,description}', file=sys.stderr)
+              sys.exit(1)
+          for entry in labels:
+              name = entry['name']
+              color = entry.get('color', 'cccccc').lstrip('#')
+              desc = entry.get('description', '')
+              cmd = ['gh', 'label', 'create', name, '--color', color, '--description', desc, '--force']
+              r = subprocess.run(cmd, capture_output=True, text=True)
+              status = 'ok' if r.returncode == 0 else f'FAIL ({r.returncode})'
+              print(f'  [{status}] {name}')
+              if r.returncode != 0:
+                  print(f'    stdout: {r.stdout}')
+                  print(f'    stderr: {r.stderr}')
+          PY

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,130 @@
+name: VSDD Promotion Pipeline
+
+# Assignment-triggered promotion of issues through the VSDD lifecycle.
+#
+#   - `spec:goal` issue + org-member self-assignment
+#       → promote-goal-to-tech: agent decomposes the goal into N tech-spec
+#         sub-issues (one technical problem each) and opens them.
+#
+#   - `spec:tech` issue + org-member self-assignment
+#       → promote-tech-to-pr: 5-phase pipeline opens a draft PR
+#         (1 scaffold → 2 author tests → 3 Red gate → 4 implement → 5
+#         Green gate, with retry loops capped at 3 attempts each).
+#
+# Ownership gate: the assignment must result in at least one org-member
+# assignee on the issue. External or bot-authored issues stay dormant
+# until an org member self-assigns. This gives a single uniform HIL gate
+# for autonomous-but-supervised work across sw2m repos.
+
+on:
+  issues:
+    types: [assigned]
+  workflow_call:
+    secrets:
+      GEMINI_API_KEY:
+        required: true
+      ANTHROPIC_API_KEY:
+        required: true
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  ownership:
+    name: Verify org-member ownership
+    runs-on: ubuntu-latest
+    outputs:
+      owned: ${{ steps.check.outputs.owned }}
+      owner: ${{ steps.check.outputs.owner }}
+      kind: ${{ steps.classify.outputs.kind }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ORG: sw2m
+          ASSIGNEES_JSON: ${{ toJson(github.event.issue.assignees) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          OWNER=""
+          for login in $(jq -r '.[].login' <<< "$ASSIGNEES_JSON"); do
+            if [ -n "$login" ] && gh api "orgs/$ORG/members/$login" >/dev/null 2>&1; then
+              OWNER="$login"
+              echo "Owner: $login (assignee, org member)"
+              break
+            fi
+          done
+          if [ -n "$OWNER" ]; then
+            echo "owned=true"   >> "$GITHUB_OUTPUT"
+            echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+          else
+            echo "owned=false"  >> "$GITHUB_OUTPUT"
+            echo "owner="       >> "$GITHUB_OUTPUT"
+            echo "::notice::No org-member assignee. Promotion pipeline skipped."
+          fi
+
+      - id: classify
+        env:
+          LABELS_JSON: ${{ toJson(github.event.issue.labels) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Pick the FIRST recognized spec label encountered. If both are
+          # set (a misconfiguration), prefer `spec:tech` — tech is the
+          # narrower, more actionable promotion.
+          KIND=""
+          if jq -e '.[] | select(.name == "spec:tech")' <<< "$LABELS_JSON" >/dev/null; then
+            KIND="tech"
+          elif jq -e '.[] | select(.name == "spec:goal")' <<< "$LABELS_JSON" >/dev/null; then
+            KIND="goal"
+          fi
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          if [ -z "$KIND" ]; then
+            echo "::notice::Issue has neither spec:goal nor spec:tech. Promotion pipeline is a no-op."
+          else
+            echo "Spec kind: $KIND"
+          fi
+
+  promote-goal-to-tech:
+    name: Decompose goal-spec into tech-spec sub-issues
+    needs: [ownership]
+    if: ${{ needs.ownership.outputs.owned == 'true' && needs.ownership.outputs.kind == 'goal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run promote-goal-to-tech (composite; org gate inside)
+        uses: ./.github/actions/promote-goal-to-tech
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          owner-login: ${{ needs.ownership.outputs.owner }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  promote-tech-to-pr:
+    name: Implement tech-spec via 5-phase pipeline
+    needs: [ownership]
+    if: ${{ needs.ownership.outputs.owned == 'true' && needs.ownership.outputs.kind == 'tech' }}
+    runs-on: ubuntu-latest
+    # Serialize per-issue runs to avoid race on branch creation if the
+    # same tech-spec is unassigned and reassigned quickly. `cancel-in-progress`
+    # = false: let the in-flight run finish — half-implemented PRs are
+    # worse than two ordered runs.
+    concurrency:
+      group: promote-tech-to-pr-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run promote-tech-to-pr (composite; org gate inside)
+        uses: ./.github/actions/promote-tech-to-pr
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          owner-login: ${{ needs.ownership.outputs.owner }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -10,7 +10,10 @@ on:
     # `ready_for_review` is added so jobs run when a draft is promoted to
     # ready. Drafts themselves are skipped at job level via the
     # `if: github.event.pull_request.draft != true` guard below.
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `assigned` re-fires the workflow when an org member self-assigns to
+    # an externally-authored PR (the assignment IS the ownership signal —
+    # see the `ownership` job below).
+    types: [opened, synchronize, reopened, ready_for_review, assigned]
   workflow_call:
     secrets:
       GEMINI_API_KEY:
@@ -105,9 +108,62 @@ env:
     line.
 
 jobs:
+  # Ownership gate. A PR is "owned" when its author is an sw2m org member
+  # OR any of its current assignees is. Unowned PRs (e.g. fork PRs from
+  # external contributors with no org-member assignee) are dormant — CI
+  # skips so an external contributor cannot consume agent budget. To wake
+  # an external PR up, an org member assigns themselves; `pull_request:
+  # [assigned]` re-fires this workflow and the gate now lets it through.
+  ownership:
+    name: Verify org-member ownership
+    if: github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    outputs:
+      owned: ${{ steps.check.outputs.owned }}
+      owner: ${{ steps.check.outputs.owner }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ORG: sw2m
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          ASSIGNEES_JSON: ${{ toJson(github.event.pull_request.assignees) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # NOTE: the default GITHUB_TOKEN can only see PUBLIC org
+          # memberships. Members whose membership is private are invisible
+          # to this check.
+          check_member() {
+            local login="$1"
+            [ -n "$login" ] && gh api "orgs/$ORG/members/$login" >/dev/null 2>&1
+          }
+          OWNER=""
+          if check_member "$AUTHOR"; then
+            OWNER="$AUTHOR"
+            echo "Owner: $AUTHOR (PR author, org member)"
+          else
+            for login in $(jq -r '.[].login' <<< "$ASSIGNEES_JSON"); do
+              if check_member "$login"; then
+                OWNER="$login"
+                echo "Owner: $login (assignee, org member)"
+                break
+              fi
+            done
+          fi
+          if [ -n "$OWNER" ]; then
+            echo "owned=true"  >> "$GITHUB_OUTPUT"
+            echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+          else
+            echo "owned=false" >> "$GITHUB_OUTPUT"
+            echo "owner="      >> "$GITHUB_OUTPUT"
+            echo "::notice::PR not owned: author '$AUTHOR' is not an sw2m org member and no assignee is. Phase 3 review skipped. To enable, an org member must self-assign."
+          fi
+
   prep:
     name: Compute PR diff
-    if: github.event.pull_request.draft != true
+    needs: [ownership]
+    if: ${{ github.event.pull_request.draft != true && needs.ownership.outputs.owned == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -161,11 +217,11 @@ jobs:
 
   gemini-review:
     name: Gemini adversarial review
-    needs: [prep]
+    needs: [ownership, prep]
     # Skip cleanly when GEMINI_API_KEY isn't available (e.g. fork PR without
     # secret access). Without this guard the composite action would fail
     # noisily, violating the 'advisory only — never gates' contract.
-    if: ${{ secrets.GEMINI_API_KEY != '' }}
+    if: ${{ secrets.GEMINI_API_KEY != '' && needs.ownership.outputs.owned == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -180,6 +236,11 @@ jobs:
           api-key: ${{ secrets.GEMINI_API_KEY }}
           stdin-file: gemini-stdin.txt
           output-file: review.md
+          # The owner login was identified by the ownership gate. Pass it
+          # as actor-override so the action's inner gate validates against
+          # the *PR owner*, not the workflow trigger sender (which on a
+          # fork-PR `synchronize` event can be the external pusher).
+          actor-override: ${{ needs.ownership.outputs.owner }}
 
       - name: Submit Gemini review (APPROVE / REQUEST_CHANGES)
         uses: actions/github-script@v9
@@ -206,10 +267,10 @@ jobs:
 
   claude-review:
     name: Claude adversarial review
-    needs: [prep]
+    needs: [ownership, prep]
     # Same guard as gemini-review — skip cleanly when ANTHROPIC_API_KEY isn't
     # available rather than fail noisily.
-    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+    if: ${{ secrets.ANTHROPIC_API_KEY != '' && needs.ownership.outputs.owned == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -229,6 +290,7 @@ jobs:
           stdin-file: gemini-stdin.txt
           prompt: |
             ${{ env.PHASE_3_PROMPT }}
+          actor-override: ${{ needs.ownership.outputs.owner }}
 
       - name: Submit Claude review (APPROVE / REQUEST_CHANGES)
         uses: actions/github-script@v9

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -294,12 +294,48 @@ Multi-word symbols are an indicator of poorly architected code, because they can
 
 ## CI/CD
 
-This repo's `.github/workflows/` enforces VSDD on itself. Four workflows, mirroring the pipeline:
+This repo's `.github/workflows/` enforces VSDD on itself. Six workflows, mirroring the pipeline:
 
-- **`issues.yml`** — fires on `issues: [opened, edited]`. Runs Gemini as Sarcasmotron (Phase 1c, Spec Review Gate) against the issue body and posts the critique as a comment. **Advisory only — never gates.**
-- **`pulls.yml`** — fires on `pull_request: [opened, synchronize, reopened]`. Runs *two* adversarial reviewers in parallel — Gemini and Claude — against the diff with `MEMORY.md` as the standard (Phase 3, Adversarial Refinement). Two cognitive sources per §V. Each posts a PR comment. **Advisory only — never gates.**
+- **`issues.yml`** — fires on `issues: [opened, edited, assigned]`. Runs Gemini as Sarcasmotron (Phase 1c, Spec Review Gate) against the issue body and posts the critique as a comment. **Advisory only — never gates.** Subject to the **ownership gate** (see below) — issues authored by non-org-members stay dormant until an org member self-assigns.
+- **`pulls.yml`** — fires on `pull_request: [opened, synchronize, reopened, ready_for_review, assigned]`. Runs *two* adversarial reviewers in parallel — Gemini and Claude — against the diff with `MEMORY.md` as the standard (Phase 3, Adversarial Refinement). Two cognitive sources per §V. Each posts a PR comment. **Advisory only — never gates.** Also subject to the ownership gate.
+- **`promote.yml`** — fires on `issues: [assigned]`. The assignment-triggered promotion pipeline (see below).
+- **`labels.yml`** — fires on `workflow_dispatch` and on push to `main` when `.github/labels.yml` changes. Idempotent label sync; manages `spec:goal`, `spec:tech`, `needs-human`, `ci-meta`.
 - **`test.yml`** — fires on `push` to `main` and on `pull_request`. Markdown lint, external link check (lychee), and a structural sanity check that all nine Roman-numeral sections of `MEMORY.md` are present. **Gating** — required by the branch-protection rule on `main`.
-- **`ci-meta.yml`** — fires on `pull_request` when `.github/workflows/**` or `MEMORY.md` change. Runs Gemini *and* Claude in parallel against the proposed CI workflows; both must reach consensus that the CI correctly enforces VSDD. Disagreement opens a tracked issue per gap (deduped by title) and fails the consensus check. **Surfaces red on disagreement but is not in the protection rule's required-checks list** — gaps are tracked as issues for follow-up; the user decides whether to address each before merge.
+- **`ci-meta.yml`** — fires on `pull_request` when `.github/workflows/**` or `MEMORY.md` change. Runs Gemini *and* Claude in parallel against the proposed CI workflows; both must reach consensus that the CI correctly enforces VSDD. Disagreement opens a tracked **goal-spec** issue per gap (deduped by title; labeled `spec:goal` and `ci-meta`) and fails the consensus check. The opened issues are problem-only — they describe what's missing, never propose a solution; solutions come from the promotion pipeline after an org member assigns themselves. **Surfaces red on disagreement but is not in the protection rule's required-checks list** — gaps are tracked as issues for follow-up; the user decides whether to address each before merge.
+
+### Ownership gate (HIL)
+
+CI runs are gated on **ownership**: an issue or PR is *owned* iff its author is an org member OR at least one current assignee is. Unowned items stay dormant — workflows skip until an org member self-assigns. This gives a single uniform Human-In-The-Loop control:
+
+- External or bot-authored issues/PRs cannot consume agent budget by default.
+- An org member assigning themselves IS the "I take responsibility for this" signal.
+- Re-trigger by unassigning + reassigning.
+
+The gate runs as a top-level `ownership` job in each workflow; downstream jobs `needs: [ownership]` and skip when unowned. The owner login is also threaded into the gemini/claude composite actions as `actor-override` so the inner org-member check validates against the *owner*, not the workflow trigger sender (which on a fork-PR `synchronize` event would be the external pusher).
+
+### Promotion pipeline (`promote.yml`)
+
+The promotion pipeline lets sw2m repos run autonomously with HIL only at decision points (assignment). On `issues: [assigned]`:
+
+1. **Goal → tech.** A `spec:goal` issue, when assigned to an org member, is decomposed by Claude into N tech-spec sub-issues (one technical problem each per §VII). Each new sub-issue carries `spec:tech` and a back-link to the parent goal. The agent's job is decomposition, not solution.
+
+2. **Tech → draft PR.** A `spec:tech` issue, when assigned, kicks off the **5-phase tech-to-PR pipeline** mapped to §VIII (4-Result Rule):
+
+   | Phase | Run by | Purpose |
+   | --- | --- | --- |
+   | 1. Scaffold | CI (no agent) | Branch off `main`, draft PR with `Closes #N` and the tech-spec embedded in the body. |
+   | 2. Author tests | Agent | Write new tests + identify regression set. Tests must be non-tautological and must not modify the regression set. |
+   | 3. Red gate | CI (no agent) | Run new tests (expect fail) and regression tests (expect pass). Mismatch → loop to Phase 2. **Cap: 3 retries.** |
+   | 4. Implement | Agent | Write code that makes the new tests pass without breaking regressions. Tests are immutable in this phase. |
+   | 5. Green gate | CI (no agent) | Run new tests (expect pass) and regression tests (expect pass). Mismatch → loop to Phase 4. **Cap: 3 retries.** |
+
+   On exhaustion of either retry budget the pipeline **bails**: applies `needs-human` to the issue, comments with the last test output on the issue and PR, leaves the PR draft. A human takes over.
+
+   On success the PR is left as draft; promoting to ready-for-review is a human decision and triggers `pulls.yml` Phase 3 adversarial review.
+
+   **Docs-repo carve-out.** Repos with no detectable test runner (e.g. this one) follow the §VIII N/A path: Phases 2/3/5 are skipped and Phase 4 runs once. The draft PR is the artifact for human review.
+
+### Reusing the workflows
 
 Each workflow exposes a `workflow_call:` trigger so other `sw2m` repos can reuse them:
 


### PR DESCRIPTION
## Summary

Adds the **assignment-triggered promotion pipeline** and generalizes ownership-via-assignment into a uniform HIL (Human-In-The-Loop) gate across `issues.yml`, `pulls.yml`, and the new `promote.yml`.

### What's new

- **`spec:goal` + assignment** → goal-spec is decomposed by Claude into N tech-spec sub-issues (one technical problem each per §VII). Sub-issues carry `spec:tech` and a back-link to the parent goal.
- **`spec:tech` + assignment** → 5-phase tech→PR pipeline:
  | # | Phase | Run by |
  |---|---|---|
  | 1 | Scaffold (branch + draft PR with spec embedded) | CI |
  | 2 | Author tests (new + identify regression set) | Agent |
  | 3 | Red gate (new=fail, regression=pass) — mismatch loops to (2) | CI |
  | 4 | Implement | Agent |
  | 5 | Green gate (new=pass, regression=pass) — mismatch loops to (4) | CI |

  Each retry loop caps at 3 retries (4 attempts total). On exhaustion: label `needs-human`, comment with last test output, leave PR draft.

- **Ownership gate.** A PR/issue is *owned* iff its author is an sw2m org member OR at least one current assignee is. Unowned items skip CI entirely. External or bot-authored work stays dormant until an org member self-assigns. The owner login is threaded into the gemini/claude composite actions as a new `actor-override` input.

- **`spec:goal` discipline for ci-meta.** Gap issues opened by ci-meta consensus are now goal-specs (problem-only, never propose a solution; tech detail allowed only to characterize the problem). They carry `spec:goal` so an org member assigning themselves immediately kicks the goal→tech promotion.

- **Docs-repo carve-out.** Repos with no detectable test runner follow the §VIII N/A path: Phases 2/3/5 skip; Phase 4 runs once. Draft PR is the artifact for human review.

### Files

- **new** `.github/workflows/promote.yml` — listens to `issues: [assigned]`; ownership-gates; dispatches to one of the two composite actions below.
- **new** `.github/actions/promote-goal-to-tech/action.yml` — Claude-driven goal decomposition.
- **new** `.github/actions/promote-tech-to-pr/action.yml` — 5-phase pipeline with retry loops, runner detection, no-runner carve-out.
- **new** `.github/scripts/parse-phase2-frontmatter.py` — extracts agent's end-of-response YAML (`new_test_files`, `new_test_command`, `regression_test_command`).
- **new** `.github/workflows/labels.yml` + `.github/labels.yml` — idempotent label sync (`spec:goal`, `spec:tech`, `needs-human`, `ci-meta`).
- **edit** `.github/workflows/issues.yml` — adds `assigned` trigger + ownership gate.
- **edit** `.github/workflows/pulls.yml` — adds `assigned` trigger + ownership gate; threads owner login as `actor-override`.
- **edit** `.github/workflows/ci-meta.yml` — gap-issue prompts produce goal-spec form + add `spec:goal` label on creation.
- **edit** `.github/actions/{gemini,claude}/action.yml` — accept `actor-override` input. Claude additionally accepts `allowed-tools` and `permission-mode` (default empty, preserving inference-only behavior; promote-tech-to-pr opts in to tool access).
- **edit** `MEMORY.md` — new `## CI/CD` section covers ownership gate, promotion pipeline, 5-phase table, docs-repo carve-out.

## Validation

- All YAML files parsed with `python3 -c "yaml.safe_load(...)"` ✓
- `parse-phase2-frontmatter.py` `py_compile` ✓
- `check-memory-structure.sh` ✓ (all 9 Roman-numeral sections present)

## Test plan

- [ ] CI passes on this draft PR (test.yml + ci-meta.yml).
- [ ] Promote to ready-for-review → pulls.yml runs ownership gate (author = anonhostpi, public org member) → Phase 3 review fires.
- [ ] Manually assign self to one of the existing `spec:goal` issues (e.g. #4) to exercise goal→tech in production.
- [ ] Manually assign self to a `spec:tech` issue (after the prior step opens some) to exercise the no-runner path of tech→PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)