### PR TITLE
fix(labels): keep descriptions ≤100 chars; fail-fast on oversize

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -5,13 +5,16 @@
 # Color palette: green = positive/goal, blue = technical/scoped,
 # yellow = attention-needed, gray = provenance/meta.
 
+# GitHub label descriptions are capped at 100 characters by the API
+# (HTTP 422 otherwise). Keep each `description:` line ≤100 chars.
+
 - name: "spec:goal"
   color: "0e8a16"  # green
-  description: "Goal-spec issue. Carries breadth (many goals), no implementation detail. Assignment to an org member triggers goal→tech promotion."
+  description: "Goal-spec issue. Many goals OK; no implementation detail. Assigning triggers goal→tech promotion."
 
 - name: "spec:tech"
   color: "1d76db"  # blue
-  description: "Tech-spec issue. Covers exactly one technical problem. Assignment to an org member triggers tech→PR promotion (5-phase pipeline)."
+  description: "Tech-spec issue. One technical problem. Assigning triggers tech→PR 5-phase promotion pipeline."
 
 - name: "needs-human"
   color: "fbca04"  # yellow

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -52,6 +52,18 @@ jobs:
           if not isinstance(labels, list):
               print('::error::.github/labels.yml must be a list of {name,color,description}', file=sys.stderr)
               sys.exit(1)
+          # GitHub caps label descriptions at 100 chars (HTTP 422 otherwise).
+          # Fail FAST with a clear error before we make N API calls; the
+          # whole reason this gate exists is that prior runs lost two
+          # labels silently to this exact validation error.
+          oversize = [(e['name'], len(e.get('description', ''))) for e in labels
+                      if len(e.get('description', '')) > 100]
+          if oversize:
+              print('::error::Label description(s) exceed the GitHub 100-char limit:', file=sys.stderr)
+              for name, n in oversize:
+                  print(f'  {name}: {n} chars (max 100)', file=sys.stderr)
+              sys.exit(1)
+          failed = []
           for entry in labels:
               name = entry['name']
               color = entry.get('color', 'cccccc').lstrip('#')
@@ -63,4 +75,8 @@ jobs:
               if r.returncode != 0:
                   print(f'    stdout: {r.stdout}')
                   print(f'    stderr: {r.stderr}')
+                  failed.append(name)
+          if failed:
+              print(f'::error::Label sync failed for: {", ".join(failed)}', file=sys.stderr)
+              sys.exit(1)
           PY


### PR DESCRIPTION
## Summary

The labels.yml sync silently lost \`spec:goal\` and \`spec:tech\` to HTTP 422 *description is too long (maximum is 100 characters)* when #32 merged. \`ci-meta\` and \`needs-human\` made it under the limit; the other two didn't. The job logged the failures but exited 0, so nothing alerted.

This both fixes the contents (descriptions trimmed under 100) **and** hardens the workflow so a future oversized description fails the job instead of disappearing.

## What changed

- \`.github/labels.yml\` — \`spec:goal\` and \`spec:tech\` descriptions shortened (97 / 94 chars). Added a top comment documenting the 100-char cap.
- \`.github/workflows/labels.yml\` — added two gates to the sync script:
  1. Length pre-check that fails the job with a per-label list of oversize entries before any API call.
  2. A failed-name accumulator that turns any non-zero \`gh label create\` exit into a hard job failure at the end.

## Test plan

- [ ] CI passes.
- [ ] After merge, push triggers labels.yml automatically; verify \`spec:goal\` and \`spec:tech\` appear via \`gh label list --search spec\`.
- [ ] Manually break a description (re-add a >100-char body), trigger via \`workflow_dispatch\`; confirm the job fails with the new pre-check error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)