### PR TITLE
fix(workflows): move secrets-presence check off jobs.<id>.if

### DIFF
--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -29,6 +29,8 @@ jobs:
     outputs:
       owned: ${{ steps.check.outputs.owned }}
       owner: ${{ steps.check.outputs.owner }}
+      has-gemini-key: ${{ steps.keys.outputs.has-gemini-key }}
+      has-anthropic-key: ${{ steps.keys.outputs.has-anthropic-key }}
     steps:
       - id: check
         env:
@@ -64,6 +66,18 @@ jobs:
             echo "owner="      >> "$GITHUB_OUTPUT"
             echo "::notice::Issue not owned: author '$AUTHOR' is not an sw2m org member and no assignee is. Phase 1c review skipped. To enable, an org member must self-assign."
           fi
+      - id: keys
+        # `secrets` is allowed in step env but NOT in job-level `if:`. Surface
+        # presence as a job output so reviewer jobs can gate via `needs.*`.
+        # (See pr-review.yml for the registration-failure history that
+        # forced this restructuring.)
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        shell: bash
+        run: |
+          [ -n "${GEMINI_API_KEY:-}" ]    && echo "has-gemini-key=true"    >> "$GITHUB_OUTPUT" || echo "has-gemini-key=false"    >> "$GITHUB_OUTPUT"
+          [ -n "${ANTHROPIC_API_KEY:-}" ] && echo "has-anthropic-key=true" >> "$GITHUB_OUTPUT" || echo "has-anthropic-key=false" >> "$GITHUB_OUTPUT"
 
   prep:
     name: Build Phase 1c prompt
@@ -130,7 +144,7 @@ jobs:
     needs: [ownership, prep]
     # Skip cleanly when GEMINI_API_KEY isn't available rather than fail
     # noisily — the workflow is advisory and must not gate anything.
-    if: ${{ needs.ownership.outputs.owned == 'true' && secrets.GEMINI_API_KEY != '' }}
+    if: ${{ needs.ownership.outputs.owned == 'true' && needs.ownership.outputs.has-gemini-key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -167,7 +181,7 @@ jobs:
     needs: [ownership, prep]
     # Same guard as gemini-review — skip cleanly when ANTHROPIC_API_KEY isn't
     # available rather than fail noisily.
-    if: ${{ needs.ownership.outputs.owned == 'true' && secrets.ANTHROPIC_API_KEY != '' }}
+    if: ${{ needs.ownership.outputs.owned == 'true' && needs.ownership.outputs.has-anthropic-key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -136,6 +136,8 @@ jobs:
     outputs:
       owned: ${{ steps.check.outputs.owned }}
       owner: ${{ steps.check.outputs.owner }}
+      has-gemini-key: ${{ steps.keys.outputs.has-gemini-key }}
+      has-anthropic-key: ${{ steps.keys.outputs.has-anthropic-key }}
     steps:
       - id: check
         env:
@@ -174,6 +176,20 @@ jobs:
             echo "owner="      >> "$GITHUB_OUTPUT"
             echo "::notice::PR not owned: author '$AUTHOR' is not an sw2m org member and no assignee is. Phase 3 review skipped. To enable, an org member must self-assign."
           fi
+      - id: keys
+        # `secrets` is allowed in step env but NOT in job-level `if:`. Surface
+        # presence as a job output so reviewer jobs can gate via `needs.*`.
+        # (This pattern is what unblocked workflow registration on this file —
+        # GitHub silently rejects workflows that reference `secrets` in
+        # `jobs.<id>.if`, which previously left this workflow registered with
+        # name = file path and not firing on `pull_request` events.)
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        shell: bash
+        run: |
+          [ -n "${GEMINI_API_KEY:-}" ]    && echo "has-gemini-key=true"    >> "$GITHUB_OUTPUT" || echo "has-gemini-key=false"    >> "$GITHUB_OUTPUT"
+          [ -n "${ANTHROPIC_API_KEY:-}" ] && echo "has-anthropic-key=true" >> "$GITHUB_OUTPUT" || echo "has-anthropic-key=false" >> "$GITHUB_OUTPUT"
 
   prep:
     name: Compute PR diff
@@ -409,7 +425,7 @@ jobs:
     # Skip cleanly when GEMINI_API_KEY isn't available (e.g. fork PR without
     # secret access). Without this guard the composite action would fail
     # noisily, violating the 'advisory only — never gates' contract.
-    if: ${{ secrets.GEMINI_API_KEY != '' && needs.ownership.outputs.owned == 'true' }}
+    if: ${{ needs.ownership.outputs.owned == 'true' && needs.ownership.outputs.has-gemini-key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -458,7 +474,7 @@ jobs:
     needs: [ownership, prep]
     # Same guard as gemini-review — skip cleanly when ANTHROPIC_API_KEY isn't
     # available rather than fail noisily.
-    if: ${{ secrets.ANTHROPIC_API_KEY != '' && needs.ownership.outputs.owned == 'true' }}
+    if: ${{ needs.ownership.outputs.owned == 'true' && needs.ownership.outputs.has-anthropic-key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

\`secrets\` is documented as available in step \`env:\` but NOT in \`jobs.<id>.if\` conditions. Both \`pr-review.yml\` and \`issue-review.yml\` referenced \`secrets.GEMINI_API_KEY != ''\` and \`secrets.ANTHROPIC_API_KEY != ''\` in job-level \`if:\` — GitHub silently rejected the workflows, they registered with name = file path (\`.github/workflows/pr-review.yml\` / \`.../issue-review.yml\`) instead of their declared names, and stopped firing on \`pull_request\` / \`issues\` events. Phase 3 review was absent on every PR; Phase 1c review absent on every issue. Only \`push\`-event 0-job failure runs were visible in the Actions tab.

The earlier rename (PR #45) didn't fix this because the underlying issue isn't the file path — it's the YAML.

### Diagnosis

The two healthy workflows (\`promote.yml\`, \`ci-meta.yml\`) use only \`needs.*\` in \`jobs.<id>.if\` and register fine; the two broken ones used \`secrets.*\`. Validated against the [GitHub Actions context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) — for \`jobs.<job_id>.if\` only \`github\`, \`needs\`, \`vars\`, and \`inputs\` are allowed.

### Fix

Surface secret presence as outputs of the existing \`ownership\` job (a step's \`env:\` IS allowed to read secrets). Reviewer jobs gate on \`needs.ownership.outputs.has-gemini-key == 'true'\` / \`has-anthropic-key == 'true'\` instead of \`secrets.X != ''\`. Same behavior — fork PRs without secret access still skip cleanly — registers correctly.

Closes #44.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, \`gh workflow list --all\` shows \`VSDD Pull Request Review (Phase 3)\` and \`VSDD Issue Review (Phase 1c)\` (registered names, not the path).
- [ ] Open a fresh PR; confirm \`Gemini adversarial review\` and \`Claude adversarial review\` checks appear and run.
- [ ] Open a fresh issue; confirm both Gemini and Claude post Phase 1c review comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)