### PR TITLE
fix(pr-review): stop sending PHASE_3_PROMPT to Claude twice (closes #31)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -488,13 +488,14 @@ jobs:
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           output-file: review.md
-          # Same stdin-file pattern as Gemini — Claude has no filesystem
-          # access via the Messages API, so we embed MEMORY.md, the PR /
-          # linked-issue context, the full repo tree, and pr.diff directly
-          # in the prompt rather than asking Claude to "read" them.
+          # Same stdin-file as Gemini — `gemini-stdin.txt` already starts
+          # with `${{ env.PHASE_3_PROMPT }}`, followed by MEMORY.md, the PR /
+          # linked-issue context, the full repo tree, and pr.diff. Do NOT
+          # also pass `prompt: PHASE_3_PROMPT` here — the claude composite
+          # concatenates `prompt` + `stdin-file`, so a separate `prompt:`
+          # would deliver the system prompt twice. The gemini-review step
+          # is the correct shape (stdin-file only).
           stdin-file: gemini-stdin.txt
-          prompt: |
-            ${{ env.PHASE_3_PROMPT }}
           actor-override: ${{ needs.ownership.outputs.owner }}
 
       - name: Submit Claude review (APPROVE / REQUEST_CHANGES)


### PR DESCRIPTION
## Summary

Closes #31.

\`pr-review.yml\`'s \`prep\` job builds \`gemini-stdin.txt\` starting with \`\${{ env.PHASE_3_PROMPT }}\` followed by MEMORY.md, PR/linked-issue context, the repo tree, and pr.diff. The \`claude-review\` step was calling the claude composite with BOTH \`stdin-file: gemini-stdin.txt\` AND \`prompt: \${{ env.PHASE_3_PROMPT }}\`. The composite concatenates prompt + stdin-file, so Claude received the same multi-paragraph system prompt twice — wasted tokens, plus the model's context budget shrinks against the doubled preamble (slightly degrading review adherence).

Match the \`gemini-review\` shape: stdin-file only.

## Test plan

- [ ] CI passes.
- [ ] Phase 3 Claude review still produces a valid frontmatter+body output (no broken format from the missing inline prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)