### PR TITLE
feat(ci-meta): in-flight-PR awareness in semantic dedup (closes #39)

### DIFF
--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -522,6 +522,36 @@ jobs:
                   capture_output=True, text=True, check=True,
               )
               candidates = json.loads(r.stdout)
+
+          # Fetch open PRs and parse `Closes #N` / `Fixes #N` /
+          # `Resolves #N` references against the candidate set — used to
+          # attach `closing_prs` to each candidate so the dedup agent
+          # treats in-flight remediation as a strong duplicate signal
+          # (#39: dedup was previously blind to in-flight PRs).
+          if all_gaps and candidates:
+              r = subprocess.run(
+                  ['gh', 'pr', 'list', '--state', 'open', '--limit', '200',
+                   '--json', 'number,title,body,isDraft'],
+                  capture_output=True, text=True, check=True,
+              )
+              open_prs = json.loads(r.stdout)
+              candidate_nums = {c['number'] for c in candidates}
+              prs_by_issue = {}
+              link_re = re.compile(r'\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[: ]+#(\d+)', re.IGNORECASE)
+              for pr in open_prs:
+                  for m in link_re.finditer(pr.get('body') or ''):
+                      n = int(m.group(1))
+                      if n in candidate_nums:
+                          prs_by_issue.setdefault(n, []).append({
+                              'number': pr['number'],
+                              'title': pr['title'],
+                              'isDraft': pr.get('isDraft', False),
+                          })
+              for c in candidates:
+                  c['closing_prs'] = prs_by_issue.get(c['number'], [])
+              in_flight_count = sum(1 for c in candidates if c['closing_prs'])
+              print(f"in-flight PRs found: {sum(len(c['closing_prs']) for c in candidates)} across {in_flight_count} candidates")
+
           with open('existing-issues.json', 'w') as f:
               json.dump(candidates, f)
 
@@ -571,6 +601,8 @@ jobs:
           out.append("")
           out.append("Closed issues are still valid dedup candidates. The maintainer who closed an issue (with or without a linked PR) made a judgment that should not be re-litigated by re-flagging. The PRIMARY failure mode this is meant to catch: an issue closed without a PR (closed because it was deemed low-value, wontfix, or out of scope) gets re-flagged on the next meta-CI run because the gap technically still exists. That should be a duplicate.")
           out.append("")
+          out.append("**In-flight PRs are a strong duplicate signal.** When an existing tracked issue has one or more open PRs declared as closing it (rendered below as a `<closing-prs>` sub-element on the `<issue>` block), that gap is actively being addressed. A proposed gap matching that issue is a duplicate — even if the existing issue's title differs in wording. Mention the PR number(s) in your `rationale` so the consensus comment can surface that the remediation is in flight.")
+          out.append("")
           out.append("Match conservatively. Only call something a duplicate if you are confident the substance overlaps — when in doubt, return null and let the human decide.")
           out.append("")
           out.append("Output one verdict per proposed gap, in order. `proposed_index` is 0-based and must match the `<proposed index=N>` blocks below.")
@@ -583,6 +615,9 @@ jobs:
               out.append("<body>")
               out.append(_truncate(e.get('body', '')))
               out.append("</body>")
+              for pr in (e.get('closing_prs') or []):
+                  draft_marker = ' isDraft="true"' if pr.get('isDraft') else ''
+                  out.append(f'<closing-prs><pr number="{pr["number"]}"{draft_marker}>{pr["title"]}</pr></closing-prs>')
               out.append("</issue>")
           out.append("")
           out.append("--- PROPOSED NEW GAPS ---")
@@ -683,7 +718,12 @@ jobs:
           for i, g in enumerate(proposed):
               if i in duplicate_map:
                   dup_num = duplicate_map[i]
-                  print(f"  skip (semantic dup of #{dup_num}): {g['title']}")
+                  in_flight = existing_by_num.get(dup_num, {}).get('closing_prs') or []
+                  if in_flight:
+                      pr_list = ', '.join(f"#{pr['number']}" for pr in in_flight)
+                      print(f"  skip (semantic dup of #{dup_num}; remediation in flight as {pr_list}): {g['title']}")
+                  else:
+                      print(f"  skip (semantic dup of #{dup_num}): {g['title']}")
                   opened.append(None)
                   continue
               flagged_by = ' + '.join(sorted(g['flagged_by']))
@@ -728,7 +768,13 @@ jobs:
                           flagged_by = ' + '.join(sorted(g['flagged_by']))
                           line = f"- {g['title']} _(flagged by {flagged_by})_"
                           if i in duplicate_map:
-                              line += f" — _skipped: dup of #{duplicate_map[i]}_"
+                              dup_num = duplicate_map[i]
+                              in_flight = existing_by_num.get(dup_num, {}).get('closing_prs') or []
+                              if in_flight:
+                                  pr_list = ', '.join(f"#{pr['number']}" for pr in in_flight)
+                                  line += f" — _skipped: dup of #{dup_num}; remediation in flight as {pr_list}_"
+                              else:
+                                  line += f" — _skipped: dup of #{dup_num}_"
                           elif opened[i]:
                               line += f" — {opened[i]}"
                           f.write(line + "\n")


### PR DESCRIPTION
## Summary

Closes #39.

The semantic dedup in \`consensus\` was previously blind to open PRs that declared \`Closes #N\` against existing tracked gap issues — a proposed gap matching such an issue would only be skipped on title/body similarity, not on the strong signal that remediation is already in flight. This PR teaches the dedup about in-flight remediation as a first-class concept.

## What changed

| Step | Change |
|---|---|
| \`prep-dedup\` | Fetches open PRs in addition to ci-meta-labeled issues. Parses each PR body for \`Closes/Fixes/Resolves #N\` references. Attaches \`closing_prs: [{number,title,isDraft}]\` to each candidate. |
| \`Build Gemini dedup input\` | Renders \`<closing-prs>\` sub-elements inside each \`<issue>\` block. Prompt updated to call in-flight PRs a STRONG duplicate signal and ask the agent to mention the PR in its \`rationale\`. |
| \`Open non-duplicate gap issues\` | Skip log lines + step-summary lines now include in-flight PR numbers: \`skip (semantic dup of #X; remediation in flight as #Y, #Z)\`. |

## Test plan

- [ ] CI passes on this PR.
- [ ] On the next ci-meta run after merge, if any flagged gap matches an issue with an open closing PR, the consensus log shows \`remediation in flight as #N\` in the skip line and the step summary surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)