### PR TITLE
fix(pr-review): add purity-boundary check to PHASE_3_PROMPT (closes #53)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -90,6 +90,7 @@ env:
     - Spec-discipline violations: tech-spec issues bundling >1 problem (§VII)
     - Security Surface (§II Phase 3): input validation gaps, injection vectors (SQL/command/path), unsafe deserialization, missing auth/authz checks
     - Spec gaps revealed by implementation (§II Phase 3): behavior in the diff that the spec doesn't cover
+    - Purity-boundary violations (§II Phase 5): newly-introduced side effects (I/O, mutable globals, time/random reads, network calls) inside a function or module the spec marks as a pure core. Flag any new dependency from a pure unit on impure infrastructure.
 
     # OUTPUT FORMAT (strict)
 


### PR DESCRIPTION
## Summary

Closes #53.

Phase 3 review previously omitted the purity-boundary audit specified in MEMORY.md §II Phase 5. Adds a single bullet to the \"Look ONLY for:\" list of \`PHASE_3_PROMPT\`:

> Purity-boundary violations (§II Phase 5): newly-introduced side effects (I/O, mutable globals, time/random reads, network calls) inside a function or module the spec marks as a pure core. Flag any new dependency from a pure unit on impure infrastructure.

## Test plan

- [ ] CI passes.
- [ ] On a follow-up PR introducing an I/O call inside a `pure/` directory or similarly-marked function, confirm Phase 3 reviewers flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)