### PR TITLE
fix(promote-tech-to-pr): scope Phase 4 prompt to runner-present repos (closes #49)

### DIFF
--- a/.github/actions/promote-tech-to-pr/action.yml
+++ b/.github/actions/promote-tech-to-pr/action.yml
@@ -461,8 +461,31 @@ runs:
           echo "=== Phase 4 — Implement (attempt $attempt of $ATTEMPTS) ==="
 
           PHASE4_INPUT=$(mktemp)
-          {
-            cat <<'PROMPT_EOF'
+          if [ "$NO_RUNNER" = "true" ]; then
+            # Docs / no-runner repo: skip test-centric framing entirely.
+            # The agent has no Phase 2 tests to satisfy and will only
+            # confuse itself if told to "make the new tests pass" or
+            # "do not modify test files" when neither exists. (#49)
+            PHASE4_HEAD=$(cat <<'PROMPT_EOF'
+        # TASK
+
+        You are running Phase 4 of the VSDD tech-to-PR pipeline on a
+        repository with no test runner detected (§VIII is N/A here).
+        Your job:
+
+        1. Read the embedded tech-spec issue.
+        2. Implement the spec using your tools (Write, Edit, Bash, Read).
+        3. Be minimal — only the changes the spec actually requires.
+           Avoid scope creep, refactors, or speculative abstractions.
+
+        Inputs are EMBEDDED below. Do not look for files on disk you did
+        not check out.
+
+        ---
+        PROMPT_EOF
+            )
+          else
+            PHASE4_HEAD=$(cat <<'PROMPT_EOF'
         # TASK
 
         You are running Phase 4 of the VSDD tech-to-PR pipeline. The tests
@@ -483,6 +506,10 @@ runs:
 
         ---
         PROMPT_EOF
+            )
+          fi
+          {
+            printf '%s\n' "$PHASE4_HEAD"
             printf -- '--- MEMORY.md ---\n'
             cat MEMORY.md
             printf '\n--- TECH-SPEC ISSUE TITLE ---\n'


### PR DESCRIPTION
## Summary

Closes #49.

Phase 4's prompt was hardcoded with test-centric framing even when the pipeline detected no test runner. Phases 2/3/5 already short-circuit on the no-runner path, but Phase 4's prompt still implied tests exist — leaving the agent to either invent tests-that-aren't-there or hallucinate references to the regression set.

Branch the prompt head on \`NO_RUNNER\`:
- **has-runner**: original 5-step framing (tests are immutable, must pass).
- **no-runner**: 3-step framing (read spec, implement minimally, no test references).

Both variants feed the same MEMORY.md + tech-spec body suffix.

## Test plan

- [ ] CI passes.
- [ ] On a docs-shaped repo, the no-runner branch runs and the agent's Phase 4 output no longer mentions tests / regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)