### PR TITLE
fix(ci-meta): skip consensus on draft PRs to clear stale FAILURE (closes #52)

### DIFF
--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -430,7 +430,14 @@ jobs:
     name: Consensus + open issues for gaps
     needs: [gemini-eval, claude-eval]
     runs-on: ubuntu-latest
-    if: always()
+    # `always()` so consensus runs even when reviewers fail (we want a
+    # report of what failed). BUT: skip the whole consensus job on draft
+    # PRs — `prep`, `gemini-eval`, and `claude-eval` all carry a
+    # `draft != true` guard and SKIP on drafts; without the same guard
+    # here, consensus would try to fail-fast on the SKIPPED reviewers and
+    # record a FAILURE check that lingers in the required-checks rollup
+    # and pollutes branch protection on the next push (#52).
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft != true) }}
     # Serialize issue creation across concurrent runs of this workflow.
     # Without this, two concurrent PRs identifying the same gap can both
     # see "no existing issue" and create duplicates (TOCTOU between


### PR DESCRIPTION
## Summary

Closes #52.

\`prep\`, \`gemini-eval\`, and \`claude-eval\` already skip on draft PRs (the \`if: ... draft != true\` guard). The \`consensus\` job had \`if: always()\` without the draft guard, so it ran on draft PRs anyway and its fail-fast step treated the SKIPPED reviewers as a failure. The resulting FAILURE check lingered in the required-checks rollup and blocked the merge gate on the very next push, even after a successful non-draft run had reported SUCCESS.

Symptom: every recent PR (#50, #51) needed an extra \`ci: re-trigger to clear stale FAILURE\` empty commit just to unblock its merge gate.

Add the same draft guard to \`consensus\`.

## Test plan

- [ ] CI passes.
- [ ] On a follow-up draft PR pushed before \`gh pr ready\`, no \`Consensus + open issues for gaps: FAILURE\` check appears in the rollup. Marking ready and pushing should yield a clean merge gate without an extra retrigger commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)