### PR TITLE
fix(pr-review): fetch base ref by name for merge-base lookup (closes #58)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -207,8 +207,18 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin "$BASE_SHA" --depth=1 || true
+          # Need both BASE_SHA and HEAD_SHA reachable from local history
+          # to compute their merge-base. Checkout above uses
+          # `fetch-depth: 0` against `ref: HEAD_SHA`, which gets HEAD's
+          # full lineage but does NOT pull the base branch separately —
+          # if main has commits not in HEAD's lineage, BASE_SHA may not
+          # be present. Fetch the base ref by name (full history) so the
+          # merge-base lookup succeeds. The earlier `git fetch origin
+          # $BASE_SHA --depth=1` was the bug — single-commit shallow
+          # fetches don't pull the merge-base ancestor (#58).
+          git fetch origin "$BASE_REF" --no-tags
           git diff "$BASE_SHA"..."$HEAD_SHA" > pr.diff
           wc -l pr.diff
           # Truncate by LINES, not bytes — byte truncation can slice mid-line,


### PR DESCRIPTION
## Summary

Closes #58.

The \`Compute PR diff\` step in \`pr-review.yml\`'s \`prep\` job failed on real PRs with \`fatal: <BASE>...<HEAD>: no merge base\` whenever main had commits not in the PR branch's lineage. The shallow single-commit fetch (\`git fetch origin "\$BASE_SHA" --depth=1\`) brought BASE_SHA in but no ancestors, so \`git diff BASE...HEAD\` couldn't find a common ancestor.

**Concrete failure:** PR #57 run id 25015169794, exit 128 on \`Compute PR diff\`. Every Phase 3 reviewer (Gemini, Claude, §IX symbol-audit) SKIPPED. Phase 3 has been silently absent on most non-trivial PRs since pr-review.yml started firing (post-#46).

Fix: fetch the base branch by name (\`git fetch origin "\$BASE_REF" --no-tags\`, full history, no depth limit) instead of by SHA with \`--depth=1\`. Combined with the existing \`fetch-depth: 0\` on the checkout, both BASE_SHA and HEAD_SHA are guaranteed to be in the local history for the merge-base lookup.

## Test plan

- [ ] CI passes — including \`Gemini adversarial review\` and \`Claude adversarial review\` actually completing (not skipping due to a failed \`Compute PR diff\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)