### PR TITLE
fix(reviews): downgrade self-review on bot-authored PRs to comment (closes #66)

### DIFF
--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -836,26 +836,26 @@ jobs:
               lines.push(``);
             }
             lines.push(`---`, `_Automated meta-review per MEMORY.md §I (Adversary). Two cognitive sources required to reach consensus._`);
-            // GitHub rejects `pulls.createReview` when the review actor
-            // matches the PR author with HTTP 422 "Review Can not approve
-            // your own pull request". `promote-tech-to-pr`'s artifact PRs
-            // are bot-authored by `github-actions[bot]`; the consensus
-            // step also runs as `github-actions[bot]`, so the API call
-            // would always fail on those PRs and fail the required
-            // status check (#66). When the actor matches the author,
-            // downgrade to a regular PR comment — same content, no
-            // verdict, no API rejection. Branch protection still gates
-            // on the Consensus job's overall conclusion (which now
-            // succeeds), and the comment surfaces the same rationale.
+            // GitHub rejects `pulls.createReview` with HTTP 422 "Review
+            // Can not approve your own pull request" when the review
+            // actor matches the PR author. `promote-tech-to-pr`'s
+            // artifact PRs are bot-authored, and the consensus step
+            // runs under that same bot, so the API call would always
+            // fail on those PRs and fail the required status check
+            // (#66). Detect actor==author dynamically via the API caller
+            // identity (works for GITHUB_TOKEN, PATs, and custom GitHub
+            // Apps alike — not hardcoded against any specific bot
+            // login) and downgrade to `issues.createComment`. Same
+            // content, no verdict, no API rejection. Branch protection
+            // still gates on the Consensus job's overall conclusion.
             const prAuthor = context.payload.pull_request?.user?.login;
-            const isSelfReview = prAuthor && prAuthor === 'github-actions[bot]';
-            if (isSelfReview) {
-              const header = `**VSDD CI Meta-Review** _(${event} would be rejected: PR is bot-authored, posting as comment)_\n\n`;
+            const me = (await github.rest.users.getAuthenticated()).data.login;
+            if (prAuthor && prAuthor === me) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: header + lines.join('\n'),
+                body: `_(${event} would be rejected: PR is authored by the same identity as the review actor, posting as comment)_\n\n` + lines.join('\n'),
               });
             } else {
               await github.rest.pulls.createReview({

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -842,15 +842,19 @@ jobs:
             // artifact PRs are bot-authored, and the consensus step
             // runs under that same bot, so the API call would always
             // fail on those PRs and fail the required status check
-            // (#66). Detect actor==author dynamically via the API caller
-            // identity (works for GITHUB_TOKEN, PATs, and custom GitHub
-            // Apps alike — not hardcoded against any specific bot
-            // login) and downgrade to `issues.createComment`. Same
-            // content, no verdict, no API rejection. Branch protection
-            // still gates on the Consensus job's overall conclusion.
+            // (#66). Downgrade to `issues.createComment` in that case —
+            // same content, no verdict, no API rejection.
+            //
+            // Hardcoded against `'github-actions[bot]'` because the
+            // dynamic alternative `github.rest.users.getAuthenticated()`
+            // returns HTTP 403 "Resource not accessible by integration"
+            // when the workflow runs under the default GITHUB_TOKEN.
+            // Spec annotation: this assumes all reviewer-submission
+            // steps run under the default GITHUB_TOKEN. If the workflow
+            // is ever switched to a PAT or a custom GitHub App, this
+            // heuristic must be updated at the same change.
             const prAuthor = context.payload.pull_request?.user?.login;
-            const me = (await github.rest.users.getAuthenticated()).data.login;
-            if (prAuthor && prAuthor === me) {
+            if (prAuthor === 'github-actions[bot]') {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -836,10 +836,33 @@ jobs:
               lines.push(``);
             }
             lines.push(`---`, `_Automated meta-review per MEMORY.md §I (Adversary). Two cognitive sources required to reach consensus._`);
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              event,
-              body: lines.join('\n'),
-            });
+            // GitHub rejects `pulls.createReview` when the review actor
+            // matches the PR author with HTTP 422 "Review Can not approve
+            // your own pull request". `promote-tech-to-pr`'s artifact PRs
+            // are bot-authored by `github-actions[bot]`; the consensus
+            // step also runs as `github-actions[bot]`, so the API call
+            // would always fail on those PRs and fail the required
+            // status check (#66). When the actor matches the author,
+            // downgrade to a regular PR comment — same content, no
+            // verdict, no API rejection. Branch protection still gates
+            // on the Consensus job's overall conclusion (which now
+            // succeeds), and the comment surfaces the same rationale.
+            const prAuthor = context.payload.pull_request?.user?.login;
+            const isSelfReview = prAuthor && prAuthor === 'github-actions[bot]';
+            if (isSelfReview) {
+              const header = `**VSDD CI Meta-Review** _(${event} would be rejected: PR is bot-authored, posting as comment)_\n\n`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: header + lines.join('\n'),
+              });
+            } else {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                event,
+                body: lines.join('\n'),
+              });
+            }

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -853,8 +853,8 @@ jobs:
             // steps run under the default GITHUB_TOKEN. If the workflow
             // is ever switched to a PAT or a custom GitHub App, this
             // heuristic must be updated at the same change.
-            const prAuthor = context.payload.pull_request?.user?.login;
-            if (prAuthor === 'github-actions[bot]') {
+            const author = context.payload.pull_request?.user?.login;
+            if (author === 'github-actions[bot]') {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -474,8 +474,8 @@ jobs:
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
             // Self-review guard — see ci-meta.yml's consensus step
             // for the rationale and the spec annotation about hardcoding.
-            const prAuthor = context.payload.pull_request?.user?.login;
-            if (prAuthor === 'github-actions[bot]') {
+            const author = context.payload.pull_request?.user?.login;
+            if (author === 'github-actions[bot]') {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -537,8 +537,8 @@ jobs:
             const header = `**VSDD Phase 3 — Claude adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
             // Self-review guard — same as the gemini-review step.
-            const prAuthor = context.payload.pull_request?.user?.login;
-            if (prAuthor === 'github-actions[bot]') {
+            const author = context.payload.pull_request?.user?.login;
+            if (author === 'github-actions[bot]') {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -472,17 +472,19 @@ jobs:
             const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
             const header = `**VSDD Phase 3 — Gemini adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
-            // Self-review guard: see ci-meta.yml's consensus step for the
-            // explanation. Bot-authored PRs (promote-tech-to-pr artifacts)
-            // can't be reviewed by the same bot identity, so downgrade to
-            // a comment.
+            // Self-review guard: see ci-meta.yml's consensus step for
+            // the rationale. Detect actor==author dynamically via
+            // getAuthenticated() rather than hardcoded against any
+            // specific bot login, so this works under GITHUB_TOKEN,
+            // PATs, and custom GitHub Apps alike.
             const prAuthor = context.payload.pull_request?.user?.login;
-            if (prAuthor === 'github-actions[bot]') {
+            const me = (await github.rest.users.getAuthenticated()).data.login;
+            if (prAuthor && prAuthor === me) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: header + `_(${event} would be rejected: PR is bot-authored, posting as comment)_\n\n` + body + footer,
+                body: header + `_(${event} would be rejected: PR author == review actor, posting as comment)_\n\n` + body + footer,
               });
             } else {
               await github.rest.pulls.createReview({
@@ -540,12 +542,13 @@ jobs:
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
             // Self-review guard — same as the gemini-review step.
             const prAuthor = context.payload.pull_request?.user?.login;
-            if (prAuthor === 'github-actions[bot]') {
+            const me = (await github.rest.users.getAuthenticated()).data.login;
+            if (prAuthor && prAuthor === me) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: header + `_(${event} would be rejected: PR is bot-authored, posting as comment)_\n\n` + body + footer,
+                body: header + `_(${event} would be rejected: PR author == review actor, posting as comment)_\n\n` + body + footer,
               });
             } else {
               await github.rest.pulls.createReview({

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -472,13 +472,27 @@ jobs:
             const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
             const header = `**VSDD Phase 3 — Gemini adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              event,
-              body: header + body + footer,
-            });
+            // Self-review guard: see ci-meta.yml's consensus step for the
+            // explanation. Bot-authored PRs (promote-tech-to-pr artifacts)
+            // can't be reviewed by the same bot identity, so downgrade to
+            // a comment.
+            const prAuthor = context.payload.pull_request?.user?.login;
+            if (prAuthor === 'github-actions[bot]') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: header + `_(${event} would be rejected: PR is bot-authored, posting as comment)_\n\n` + body + footer,
+              });
+            } else {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                event,
+                body: header + body + footer,
+              });
+            }
 
   claude-review:
     name: Claude adversarial review
@@ -524,10 +538,21 @@ jobs:
             const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
             const header = `**VSDD Phase 3 — Claude adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              event,
-              body: header + body + footer,
-            });
+            // Self-review guard — same as the gemini-review step.
+            const prAuthor = context.payload.pull_request?.user?.login;
+            if (prAuthor === 'github-actions[bot]') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: header + `_(${event} would be rejected: PR is bot-authored, posting as comment)_\n\n` + body + footer,
+              });
+            } else {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                event,
+                body: header + body + footer,
+              });
+            }

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -472,14 +472,10 @@ jobs:
             const event = verdict === 'pass' ? 'APPROVE' : 'REQUEST_CHANGES';
             const header = `**VSDD Phase 3 — Gemini adversarial review** _(advisory; status check is what gates merge)_  \n_Verdict: \`${verdict ?? 'unparseable'}\`_\n\n`;
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
-            // Self-review guard: see ci-meta.yml's consensus step for
-            // the rationale. Detect actor==author dynamically via
-            // getAuthenticated() rather than hardcoded against any
-            // specific bot login, so this works under GITHUB_TOKEN,
-            // PATs, and custom GitHub Apps alike.
+            // Self-review guard — see ci-meta.yml's consensus step
+            // for the rationale and the spec annotation about hardcoding.
             const prAuthor = context.payload.pull_request?.user?.login;
-            const me = (await github.rest.users.getAuthenticated()).data.login;
-            if (prAuthor && prAuthor === me) {
+            if (prAuthor === 'github-actions[bot]') {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -542,8 +538,7 @@ jobs:
             const footer = `\n\n---\n_Automated review per MEMORY.md §II Phase 3._`;
             // Self-review guard — same as the gemini-review step.
             const prAuthor = context.payload.pull_request?.user?.login;
-            const me = (await github.rest.users.getAuthenticated()).data.login;
-            if (prAuthor && prAuthor === me) {
+            if (prAuthor === 'github-actions[bot]') {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Closes #66.

GitHub rejects \`pulls.createReview\` with HTTP 422 \"Review Can not approve your own pull request\" when the actor matches the PR author. \`promote-tech-to-pr\`'s artifact PRs are authored by \`github-actions[bot]\`, and ci-meta's consensus step + pr-review's gemini/claude review steps all run under that same bot identity — every API call to submit a review on a pipeline-generated PR fails, breaking the merge gate even when every cheaper check is green.

Surfaced concretely on PR #64 (the first end-to-end smoke test of \`promote-tech-to-pr\`); both reviewers reported \`verdict: pass\` but the consensus step's \`createReview\` call hit HTTP 422 and failed the required \`Consensus + open issues for gaps\` check. Branch protection blocked merge even via \`--admin\` (ruleset disallows admin bypass).

## Fix

Detect the actor-equals-author case and downgrade to \`issues.createComment\`. Same content, no review verdict, no API rejection. Branch protection still gates on the consensus job's overall conclusion (which now succeeds), and the comment surfaces the same rationale plus a parenthetical noting which event (APPROVE / REQUEST_CHANGES) WOULD have been requested.

Three call sites:
- \`ci-meta.yml\` Submit consensus PR review
- \`pr-review.yml\` Submit Gemini review
- \`pr-review.yml\` Submit Claude review

## Test plan

- [ ] CI passes on this PR (anonhostpi-authored, so reviews fire normally).
- [ ] After merge, re-trigger PR #64 (or the next promote-tech-to-pr artifact PR) and confirm the consensus job reports the verdict via PR comment without HTTP 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)