### PR TITLE
fix(promote): write scratch files to RUNNER_TEMP, not cwd (closes #65)

### DIFF
--- a/.github/actions/promote-tech-to-pr/action.yml
+++ b/.github/actions/promote-tech-to-pr/action.yml
@@ -295,15 +295,16 @@ runs:
           fi
 
           # Extract the frontmatter from the END of the agent output.
-          # The parser writes phase2-meta.json and prints declared files.
-          NEW_FILES=$(python3 .github/scripts/parse-phase2-frontmatter.py "$PHASE2_OUTPUT" 2>phase2-parse-err.log) || {
-            last_failure="Phase 2 frontmatter parse failed (attempt $attempt). $(cat phase2-parse-err.log)"
+          # Parser writes ${RUNNER_TEMP}/phase2-meta.json (out-of-tree per
+          # #65) and prints declared files.
+          NEW_FILES=$(python3 .github/scripts/parse-phase2-frontmatter.py "$PHASE2_OUTPUT" "${RUNNER_TEMP}/phase2-meta.json" 2>${RUNNER_TEMP}/phase2-parse-err.log) || {
+            last_failure="Phase 2 frontmatter parse failed (attempt $attempt). $(cat ${RUNNER_TEMP}/phase2-parse-err.log)"
             echo "::warning::$last_failure"
             continue
           }
 
-          NEW_CMD=$(jq -r '.new_cmd' phase2-meta.json)
-          REG_CMD=$(jq -r '.reg_cmd' phase2-meta.json)
+          NEW_CMD=$(jq -r '.new_cmd' ${RUNNER_TEMP}/phase2-meta.json)
+          REG_CMD=$(jq -r '.reg_cmd' ${RUNNER_TEMP}/phase2-meta.json)
 
           if [ -z "$NEW_CMD" ] || [ -z "$REG_CMD" ] || [ -z "$NEW_FILES" ]; then
             last_failure="Phase 2 declared empty new_test_files / new_cmd / reg_cmd (attempt $attempt). The agent did not produce a usable test set."
@@ -318,9 +319,9 @@ runs:
           echo ""
           echo "=== Phase 3 — Red gate (attempt $attempt) ==="
           set +e
-          eval "$NEW_CMD" >red-new.log 2>&1
+          eval "$NEW_CMD" >${RUNNER_TEMP}/red-new.log 2>&1
           NEW_RC=$?
-          eval "$REG_CMD" >red-reg.log 2>&1
+          eval "$REG_CMD" >${RUNNER_TEMP}/red-reg.log 2>&1
           REG_RC=$?
           set -e
 
@@ -356,19 +357,19 @@ runs:
             echo ""
             echo "Last new-tests output:"
             echo '```'
-            tail -100 red-new.log 2>/dev/null || true
+            tail -100 ${RUNNER_TEMP}/red-new.log 2>/dev/null || true
             echo '```'
             echo ""
             echo "Last regression-tests output:"
             echo '```'
-            tail -100 red-reg.log 2>/dev/null || true
+            tail -100 ${RUNNER_TEMP}/red-reg.log 2>/dev/null || true
             echo '```'
-          } > red-bail.md
+          } > ${RUNNER_TEMP}/red-bail.md
           echo "bailed=true" >> "$GITHUB_OUTPUT"
         else
           echo "bailed=false" >> "$GITHUB_OUTPUT"
           # Persist the test commands for Phase 5.
-          cp phase2-meta.json phase2-meta-final.json
+          cp ${RUNNER_TEMP}/phase2-meta.json ${RUNNER_TEMP}/phase2-meta-final.json
         fi
 
     - name: Bail on Red-gate exhaustion
@@ -393,7 +394,7 @@ runs:
           echo "interacts with the regression set in a way the agent can't"
           echo "isolate._"
           echo ""
-          cat red-bail.md
+          cat ${RUNNER_TEMP}/red-bail.md
           echo ""
           echo "@$OWNER_LOGIN — over to you. Inspect the draft PR (#$PR_NUMBER), "
           echo "either refine the tech-spec into smaller pieces or take over"
@@ -447,8 +448,8 @@ runs:
           REG_CMD=""
         else
           ATTEMPTS=$((MAX_RETRIES + 1))
-          NEW_CMD=$(jq -r '.new_cmd' phase2-meta-final.json)
-          REG_CMD=$(jq -r '.reg_cmd' phase2-meta-final.json)
+          NEW_CMD=$(jq -r '.new_cmd' ${RUNNER_TEMP}/phase2-meta-final.json)
+          REG_CMD=$(jq -r '.reg_cmd' ${RUNNER_TEMP}/phase2-meta-final.json)
         fi
 
         attempt=0
@@ -550,9 +551,9 @@ runs:
           echo ""
           echo "=== Phase 5 — Green gate (attempt $attempt) ==="
           set +e
-          eval "$NEW_CMD" >green-new.log 2>&1
+          eval "$NEW_CMD" >${RUNNER_TEMP}/green-new.log 2>&1
           NEW_RC=$?
-          eval "$REG_CMD" >green-reg.log 2>&1
+          eval "$REG_CMD" >${RUNNER_TEMP}/green-reg.log 2>&1
           REG_RC=$?
           set -e
 
@@ -590,12 +591,12 @@ runs:
             echo ""
             if [ "$NO_RUNNER" != "true" ]; then
               echo "Last new-tests output:"; echo '```'
-              tail -100 green-new.log 2>/dev/null || true; echo '```'
+              tail -100 ${RUNNER_TEMP}/green-new.log 2>/dev/null || true; echo '```'
               echo ""
               echo "Last regression-tests output:"; echo '```'
-              tail -100 green-reg.log 2>/dev/null || true; echo '```'
+              tail -100 ${RUNNER_TEMP}/green-reg.log 2>/dev/null || true; echo '```'
             fi
-          } > green-bail.md
+          } > ${RUNNER_TEMP}/green-bail.md
           echo "bailed=true" >> "$GITHUB_OUTPUT"
         else
           echo "bailed=false" >> "$GITHUB_OUTPUT"
@@ -621,7 +622,7 @@ runs:
           echo "(from Phase 2) are committed on the branch; the failed"
           echo "Phase 4 implementation attempts have been discarded._"
           echo ""
-          cat green-bail.md
+          cat ${RUNNER_TEMP}/green-bail.md
           echo ""
           echo "@$OWNER_LOGIN — over to you. Either implement by hand on"
           echo "branch \`${BRANCH:-the PR branch}\`, or refine the tech-spec"

--- a/.github/actions/promote-tech-to-pr/action.yml
+++ b/.github/actions/promote-tech-to-pr/action.yml
@@ -64,11 +64,11 @@ runs:
         ISSUE_NUMBER: ${{ inputs.issue-number }}
       run: |
         set -euo pipefail
-        gh issue view "$ISSUE_NUMBER" --json title,body,number,url > tech.json
-        jq -r '.title' tech.json > tech-title.txt
-        jq -r '.body'  tech.json > tech-body.txt
-        jq -r '.url'   tech.json > tech-url.txt
-        echo "tech-spec: $(cat tech-title.txt)"
+        gh issue view "$ISSUE_NUMBER" --json title,body,number,url > ${RUNNER_TEMP}/tech.json
+        jq -r '.title' ${RUNNER_TEMP}/tech.json > ${RUNNER_TEMP}/tech-title.txt
+        jq -r '.body'  ${RUNNER_TEMP}/tech.json > ${RUNNER_TEMP}/tech-body.txt
+        jq -r '.url'   ${RUNNER_TEMP}/tech.json > ${RUNNER_TEMP}/tech-url.txt
+        echo "tech-spec: $(cat ${RUNNER_TEMP}/tech-title.txt)"
 
     - name: Detect test runner
       id: runner
@@ -151,7 +151,7 @@ runs:
           echo "pr-number=$EXISTING_PR" >> "$GITHUB_OUTPUT"
           echo "Reusing existing PR #$EXISTING_PR for branch $BRANCH"
         else
-          TITLE=$(cat tech-title.txt)
+          TITLE=$(cat ${RUNNER_TEMP}/tech-title.txt)
           BODY_FILE=$(mktemp)
           {
             echo "Closes #$ISSUE_NUMBER"
@@ -163,7 +163,7 @@ runs:
             echo ""
             echo "## Embedded tech-spec"
             echo ""
-            cat tech-body.txt
+            cat ${RUNNER_TEMP}/tech-body.txt
           } > "$BODY_FILE"
           PR_URL=$(gh pr create --draft --base "$BASE_BRANCH" --head "$BRANCH" --title "$TITLE" --body-file "$BODY_FILE")
           PR_NUMBER=$(basename "$PR_URL")
@@ -201,15 +201,15 @@ runs:
           claude --print --model "$primary" \
             --allowed-tools "Bash Edit Write Read Glob Grep" \
             --permission-mode bypassPermissions \
-            < "$input" > "$output" 2>claude-err.log
+            < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
           local rc=$?
           if [ $rc -ne 0 ]; then
             echo "::warning::Phase agent: primary $primary exited $rc; falling back to $fallback"
-            tail -50 claude-err.log
+            tail -50 ${RUNNER_TEMP}/claude-err.log
             claude --print --model "$fallback" \
               --allowed-tools "Bash Edit Write Read Glob Grep" \
               --permission-mode bypassPermissions \
-              < "$input" > "$output" 2>claude-err.log
+              < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
             rc=$?
           fi
           set -e
@@ -281,16 +281,16 @@ runs:
             printf -- '--- MEMORY.md ---\n'
             cat MEMORY.md
             printf '\n--- TECH-SPEC ISSUE TITLE ---\n'
-            cat tech-title.txt
+            cat ${RUNNER_TEMP}/tech-title.txt
             printf '\n--- TECH-SPEC ISSUE BODY ---\n'
-            cat tech-body.txt
+            cat ${RUNNER_TEMP}/tech-body.txt
           } > "$PHASE2_INPUT"
 
           PHASE2_OUTPUT=$(mktemp)
           if ! invoke_claude "$PHASE2_INPUT" "$PHASE2_OUTPUT"; then
             last_failure="Phase 2 agent (attempt $attempt) exited non-zero on both primary and fallback models."
             echo "::warning::$last_failure"
-            tail -50 claude-err.log || true
+            tail -50 ${RUNNER_TEMP}/claude-err.log || true
             continue
           fi
 
@@ -426,15 +426,15 @@ runs:
           claude --print --model "$primary" \
             --allowed-tools "Bash Edit Write Read Glob Grep" \
             --permission-mode bypassPermissions \
-            < "$input" > "$output" 2>claude-err.log
+            < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
           local rc=$?
           if [ $rc -ne 0 ]; then
             echo "::warning::Phase agent: primary $primary exited $rc; falling back to $fallback"
-            tail -50 claude-err.log
+            tail -50 ${RUNNER_TEMP}/claude-err.log
             claude --print --model "$fallback" \
               --allowed-tools "Bash Edit Write Read Glob Grep" \
               --permission-mode bypassPermissions \
-              < "$input" > "$output" 2>claude-err.log
+              < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
             rc=$?
           fi
           set -e
@@ -513,9 +513,9 @@ runs:
             printf -- '--- MEMORY.md ---\n'
             cat MEMORY.md
             printf '\n--- TECH-SPEC ISSUE TITLE ---\n'
-            cat tech-title.txt
+            cat ${RUNNER_TEMP}/tech-title.txt
             printf '\n--- TECH-SPEC ISSUE BODY ---\n'
-            cat tech-body.txt
+            cat ${RUNNER_TEMP}/tech-body.txt
             if [ "$NO_RUNNER" != "true" ]; then
               printf '\n--- TEST RUN COMMANDS ---\n'
               printf 'New tests command (must end up exit 0): %s\n' "$NEW_CMD"
@@ -527,7 +527,7 @@ runs:
           if ! invoke_claude "$PHASE4_INPUT" "$PHASE4_OUTPUT"; then
             last_failure="Phase 4 agent (attempt $attempt) exited non-zero on both primary and fallback models."
             echo "::warning::$last_failure"
-            tail -50 claude-err.log || true
+            tail -50 ${RUNNER_TEMP}/claude-err.log || true
             git checkout -- . && git clean -fd
             continue
           fi

--- a/.github/scripts/parse-phase2-frontmatter.py
+++ b/.github/scripts/parse-phase2-frontmatter.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """Parse Phase 2 agent output frontmatter (promote-tech-to-pr).
 
-Reads the Phase 2 output file from `sys.argv[1]`, extracts the YAML
-frontmatter block at the END of the response (the agent appends it
-after using its tools), and writes:
+Reads the Phase 2 output file from `sys.argv[1]`. Output path for the
+JSON metadata defaults to `phase2-meta.json` in cwd, but the caller
+can override via `sys.argv[2]` (the action.yml writes to
+`${RUNNER_TEMP}/phase2-meta.json` so the file isn't swept by Phase 4's
+`git add .` — see issue #65).
 
-  - phase2-meta.json — {"files": [...], "new_cmd": "...", "reg_cmd": "..."}
+Writes:
+  - <out-path> — {"files": [...], "new_cmd": "...", "reg_cmd": "..."}
   - prints each file path on stdout, one per line (so the bash caller
     can iterate or verify non-emptiness)
 
@@ -22,10 +25,11 @@ import yaml
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print('usage: parse-phase2-frontmatter.py <phase2-output-file>', file=sys.stderr)
+    if len(sys.argv) not in (2, 3):
+        print('usage: parse-phase2-frontmatter.py <phase2-output-file> [<meta-out-path>]', file=sys.stderr)
         return 2
     path = sys.argv[1]
+    out_path = sys.argv[2] if len(sys.argv) == 3 else 'phase2-meta.json'
     with open(path) as f:
         raw = f.read()
 
@@ -49,7 +53,7 @@ def main() -> int:
         print('new_test_files is not a list', file=sys.stderr)
         return 1
 
-    with open('phase2-meta.json', 'w') as f:
+    with open(out_path, 'w') as f:
         json.dump({'files': files, 'new_cmd': new_cmd, 'reg_cmd': reg_cmd}, f)
 
     for p in files:


### PR DESCRIPTION
## Summary

Closes #65.

The Phase 4 \`git add .\` was capturing pipeline scratch files (\`tech.json\`, \`tech-{title,body,url}.txt\`, \`claude-err.log\`) written to cwd by earlier steps. PR #64 (the smoke test) shipped these alongside the real implementation and required a manual cleanup commit before review.

Move all scratch files to \`\${RUNNER_TEMP}/\` — the standard GitHub Actions per-runner scratch directory. \`git add .\` no longer sees them, no .gitignore needed, no allowlist staging. The directory is auto-cleaned at end of run.

20 reference sites updated. The intentional \`.vsdd/promotion-<N>.log\` scaffold marker stays in the repo working tree (its purpose is to be a durable in-repo marker).

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, exercising \`promote-tech-to-pr\` on issues #61/#62/#63 produces draft PRs with ONLY the implementation files + the scaffold marker — no scratch files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)