### PR TITLE
chore(promote): use empty scaffold commit; clean up .vsdd/ from main

### DIFF
--- a/.github/actions/promote-tech-to-pr/action.yml
+++ b/.github/actions/promote-tech-to-pr/action.yml
@@ -131,16 +131,17 @@ runs:
           echo "Branch $BRANCH already existed; resuming."
         else
           git checkout -b "$BRANCH" "origin/$BASE_BRANCH"
-          # Make a no-op commit so the branch can be pushed and a PR opened.
+          # Empty scaffold commit so the branch can be pushed and a PR
+          # opened. The commit MESSAGE is the durable "this branch
+          # came from the promote pipeline" discriminant — any
+          # downstream check that needs to detect promote-pipeline
+          # branches greps `git log --grep='^chore(promote): scaffold'`.
           # The actual implementation lands in subsequent phases.
-          mkdir -p .vsdd
-          {
-            echo "Promotion run for issue #$ISSUE_NUMBER"
-            echo "Owner: @$OWNER_LOGIN"
-            echo "Started: $(date -u +%FT%TZ)"
-          } > .vsdd/promotion-$ISSUE_NUMBER.log
-          git add .vsdd/promotion-$ISSUE_NUMBER.log
-          git commit -m "chore(promote): scaffold for #$ISSUE_NUMBER"
+          git commit --allow-empty -m "chore(promote): scaffold for #$ISSUE_NUMBER
+
+          Promotion run for issue #$ISSUE_NUMBER
+          Owner: @$OWNER_LOGIN
+          Started: $(date -u +%FT%TZ)"
           git push -u origin "$BRANCH"
         fi
         echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"

--- a/.vsdd/promotion-60.log
+++ b/.vsdd/promotion-60.log
@@ -1,3 +1,0 @@
-Promotion run for issue #60
-Owner: @anonhostpi
-Started: 2026-04-27T20:51:17Z

--- a/.vsdd/promotion-61.log
+++ b/.vsdd/promotion-61.log
@@ -1,3 +1,0 @@
-Promotion run for issue #61
-Owner: @anonhostpi
-Started: 2026-04-27T22:19:23Z

--- a/.vsdd/promotion-62.log
+++ b/.vsdd/promotion-62.log
@@ -1,3 +1,0 @@
-Promotion run for issue #62
-Owner: @anonhostpi
-Started: 2026-04-27T22:19:28Z

--- a/.vsdd/promotion-63.log
+++ b/.vsdd/promotion-63.log
@@ -1,3 +1,0 @@
-Promotion run for issue #63
-Owner: @anonhostpi
-Started: 2026-04-27T22:19:29Z


### PR DESCRIPTION
## Summary

Closes #73.

Phase 1 of \`promote-tech-to-pr\` previously dropped a \`.vsdd/promotion-<N>.log\` marker file as the no-op scaffold commit. Squash-merging promoted those files into mainline, and main accumulated one per merged tech-spec PR forever (\`promotion-60.log\`, \`-61\`, \`-62\`, \`-63\` from the recent run).

The discriminant the marker was supposed to provide ("did this branch come from the promote pipeline?") is more idiomatically carried by the SCAFFOLD COMMIT'S MESSAGE — \`chore(promote): scaffold for #N\`. Any downstream check uses \`git log --grep\` on the branch.

## What changed

1. Replace the marker-file scaffold with \`git commit --allow-empty\` plus the original metadata moved into the commit body. No file created, nothing tracked, no accumulation.

2. \`git rm\` the four \`.vsdd/promotion-*.log\` files that already landed in main. The \`.vsdd/\` directory is removed entirely (empty after the rm).

## Test plan

- [ ] CI passes.
- [ ] After merge, a fresh \`promote-tech-to-pr\` run produces a draft PR whose only files are the actual implementation — no \`.vsdd/promotion-N.log\` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)