### PR TITLE
feat(workflows): add workflow_call trigger to red-gate workflows

### DIFF
--- a/.github/workflows/non-test-blocker.yml
+++ b/.github/workflows/non-test-blocker.yml
@@ -16,6 +16,7 @@ name: VSDD Non-test-blocker (ancestry enforcement)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call: {}
 
 permissions:
   contents: read

--- a/.github/workflows/red-conditions-gate.yml
+++ b/.github/workflows/red-conditions-gate.yml
@@ -24,6 +24,7 @@ name: VSDD Red-conditions Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Closes #75.

The two §VIII Red Gate enforcement workflows (\`red-conditions-gate.yml\` and \`non-test-blocker.yml\`) shipped without \`workflow_call:\` triggers, preventing downstream sw2m repos from consuming them via the standard thin-caller pattern that the other VSDD workflows support.

Add \`workflow_call: {}\` so a consumer (e.g. sw2m/clesty's onboarding PR) can wrap them as:

\`\`\`yaml
jobs:
  red-conditions:
    uses: sw2m/philosophies/.github/workflows/red-conditions-gate.yml@main
    secrets: inherit
\`\`\`

Non-breaking — existing direct \`pull_request\` triggers still fire on philosophies' own PRs.

## Test plan

- [ ] CI passes.
- [ ] After merge, the sw2m/clesty onboarding PR's caller workflows can resolve these workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)