### PR TITLE
feat(workflows): use absolute action paths for downstream reusability

### DIFF
--- a/.github/actions/promote-goal-to-tech/action.yml
+++ b/.github/actions/promote-goal-to-tech/action.yml
@@ -111,7 +111,7 @@ runs:
         echo "stdin.txt bytes: $(wc -c < stdin.txt)"
 
     - name: Run Claude (org-member gate inside)
-      uses: ./.github/actions/claude
+      uses: sw2m/philosophies/.github/actions/claude@main
       with:
         api-key: ${{ inputs.anthropic-api-key }}
         actor-override: ${{ inputs.owner-login }}

--- a/.github/actions/promote-tech-to-pr/action.yml
+++ b/.github/actions/promote-tech-to-pr/action.yml
@@ -297,8 +297,10 @@ runs:
 
           # Extract the frontmatter from the END of the agent output.
           # Parser writes ${RUNNER_TEMP}/phase2-meta.json (out-of-tree per
-          # #65) and prints declared files.
-          NEW_FILES=$(python3 .github/scripts/parse-phase2-frontmatter.py "$PHASE2_OUTPUT" "${RUNNER_TEMP}/phase2-meta.json" 2>${RUNNER_TEMP}/phase2-parse-err.log) || {
+          # #65) and prints declared files. Use $GITHUB_ACTION_PATH so
+          # the script resolves against THIS composite action's checkout
+          # (philosophies), not the consumer's repo checkout.
+          NEW_FILES=$(python3 "${GITHUB_ACTION_PATH}/../../scripts/parse-phase2-frontmatter.py" "$PHASE2_OUTPUT" "${RUNNER_TEMP}/phase2-meta.json" 2>${RUNNER_TEMP}/phase2-parse-err.log) || {
             last_failure="Phase 2 frontmatter parse failed (attempt $attempt). $(cat ${RUNNER_TEMP}/phase2-parse-err.log)"
             echo "::warning::$last_failure"
             continue

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: shape
-        uses: ./.github/actions/repo-shape
+        uses: sw2m/philosophies/.github/actions/repo-shape@main
       - name: Print VSDD §VIII applicability to job summary
         shell: bash
         env:
@@ -142,7 +142,7 @@ jobs:
           path: ./
 
       - name: Run Gemini
-        uses: ./.github/actions/gemini
+        uses: sw2m/philosophies/.github/actions/gemini@main
         with:
           api-key: ${{ secrets.GEMINI_API_KEY }}
           stdin-file: eval-input.txt
@@ -275,7 +275,7 @@ jobs:
           path: ./
 
       - name: Run Claude
-        uses: ./.github/actions/claude
+        uses: sw2m/philosophies/.github/actions/claude@main
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           output-file: claude-eval.md
@@ -645,7 +645,7 @@ jobs:
 
       - name: Run Gemini semantic dedup
         if: steps.prep-dedup.outputs.dedup-needed == 'true'
-        uses: ./.github/actions/gemini
+        uses: sw2m/philosophies/.github/actions/gemini@main
         with:
           api-key: ${{ secrets.GEMINI_API_KEY }}
           stdin-file: dedup-input.txt

--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -154,7 +154,7 @@ jobs:
           path: ./
 
       - name: Run Gemini (composite action; org-member gate enforced inside)
-        uses: ./.github/actions/gemini
+        uses: sw2m/philosophies/.github/actions/gemini@main
         with:
           api-key: ${{ secrets.GEMINI_API_KEY }}
           stdin-file: stdin.txt
@@ -191,7 +191,7 @@ jobs:
           path: ./
 
       - name: Run Claude (composite action; org-member gate enforced inside)
-        uses: ./.github/actions/claude
+        uses: sw2m/philosophies/.github/actions/claude@main
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           stdin-file: stdin.txt

--- a/.github/workflows/non-test-blocker.yml
+++ b/.github/workflows/non-test-blocker.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: s
-        uses: ./.github/actions/repo-shape
+        uses: sw2m/philosophies/.github/actions/repo-shape@main
 
   blocker:
     name: Non-test-commit ancestry enforcement

--- a/.github/workflows/non-test-blocker.yml
+++ b/.github/workflows/non-test-blocker.yml
@@ -47,6 +47,15 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # Fetch philosophies' scripts so this workflow works when called
+      # from a downstream sw2m repo via workflow_call.
+      - name: Fetch sw2m/philosophies scripts
+        uses: actions/checkout@v6
+        with:
+          repository: sw2m/philosophies
+          ref: main
+          path: .vsdd-philosophies
+
       - name: Walk PR commits + enforce ancestry against marker
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +84,7 @@ jobs:
           fail=0
           while read -r sha; do
             [ -z "$sha" ] && continue
-            output=$(bash .github/scripts/classify-changes.sh "$sha" \
+            output=$(bash .vsdd-philosophies/.github/scripts/classify-changes.sh "$sha" \
               ${GLOBS:+--patterns "$GLOBS"})
             tests_only=$(grep '^tests-only=' <<<"$output" | cut -d= -f2)
             if [ "$tests_only" = "true" ]; then

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -455,6 +455,15 @@ jobs:
           name: pr-context
           path: ./
 
+      # Fetch philosophies' scripts (extract-verdict.js) for downstream
+      # callers that don't have them in their checkout.
+      - name: Fetch sw2m/philosophies scripts
+        uses: actions/checkout@v6
+        with:
+          repository: sw2m/philosophies
+          ref: main
+          path: .vsdd-philosophies
+
       - name: Run Gemini (composite; org-member gate inside)
         uses: sw2m/philosophies/.github/actions/gemini@main
         with:
@@ -473,7 +482,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const { extractVerdict } = require(path.resolve('.github/scripts/extract-verdict.js'));
+            const { extractVerdict } = require(path.resolve('.vsdd-philosophies/.github/scripts/extract-verdict.js'));
             const raw = fs.readFileSync('review.md', 'utf8');
             const { verdict, body } = extractVerdict(raw);
             if (verdict !== 'pass' && verdict !== 'fail') {
@@ -516,6 +525,15 @@ jobs:
           name: pr-context
           path: ./
 
+      # Fetch philosophies' scripts (extract-verdict.js) for downstream
+      # callers that don't have them in their checkout.
+      - name: Fetch sw2m/philosophies scripts
+        uses: actions/checkout@v6
+        with:
+          repository: sw2m/philosophies
+          ref: main
+          path: .vsdd-philosophies
+
       - name: Run Claude (composite; org-member gate inside)
         uses: sw2m/philosophies/.github/actions/claude@main
         with:
@@ -537,7 +555,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const { extractVerdict } = require(path.resolve('.github/scripts/extract-verdict.js'));
+            const { extractVerdict } = require(path.resolve('.vsdd-philosophies/.github/scripts/extract-verdict.js'));
             const raw = fs.readFileSync('review.md', 'utf8');
             const { verdict, body } = extractVerdict(raw);
             if (verdict !== 'pass' && verdict !== 'fail') {

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -411,9 +411,19 @@ jobs:
           name: pr-context
           path: ./
 
+      # Fetch philosophies' scripts so this workflow works when called
+      # from a downstream sw2m repo via workflow_call (the consumer's
+      # checkout has neither symbol-audit.sh nor the other VSDD scripts).
+      - name: Fetch sw2m/philosophies scripts
+        uses: actions/checkout@v6
+        with:
+          repository: sw2m/philosophies
+          ref: main
+          path: .vsdd-philosophies
+
       - name: Run symbol audit
         run: |
-          bash .github/scripts/symbol-audit.sh pr.diff symbol-audit.md
+          bash .vsdd-philosophies/.github/scripts/symbol-audit.sh pr.diff symbol-audit.md
           echo '--- symbol-audit.md ---'
           cat symbol-audit.md
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -446,7 +446,7 @@ jobs:
           path: ./
 
       - name: Run Gemini (composite; org-member gate inside)
-        uses: ./.github/actions/gemini
+        uses: sw2m/philosophies/.github/actions/gemini@main
         with:
           api-key: ${{ secrets.GEMINI_API_KEY }}
           stdin-file: gemini-stdin.txt
@@ -507,7 +507,7 @@ jobs:
           path: ./
 
       - name: Run Claude (composite; org-member gate inside)
-        uses: ./.github/actions/claude
+        uses: sw2m/philosophies/.github/actions/claude@main
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           output-file: review.md

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run promote-goal-to-tech (composite; org gate inside)
-        uses: ./.github/actions/promote-goal-to-tech
+        uses: sw2m/philosophies/.github/actions/promote-goal-to-tech@main
         with:
           issue-number: ${{ github.event.issue.number }}
           owner-login: ${{ needs.ownership.outputs.owner }}
@@ -122,7 +122,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run promote-tech-to-pr (composite; org gate inside)
-        uses: ./.github/actions/promote-tech-to-pr
+        uses: sw2m/philosophies/.github/actions/promote-tech-to-pr@main
         with:
           issue-number: ${{ github.event.issue.number }}
           owner-login: ${{ needs.ownership.outputs.owner }}

--- a/.github/workflows/red-conditions-gate.yml
+++ b/.github/workflows/red-conditions-gate.yml
@@ -55,6 +55,15 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # Fetch philosophies' scripts so this workflow works when called
+      # from a downstream sw2m repo via workflow_call.
+      - name: Fetch sw2m/philosophies scripts
+        uses: actions/checkout@v6
+        with:
+          repository: sw2m/philosophies
+          ref: main
+          path: .vsdd-philosophies
+
       # Clause (a) — test-commits-only.
       # Walk every commit on the PR; each must classify as tests-only.
       # `classify-changes` returns `tests-only=true|false` per commit.
@@ -73,7 +82,7 @@ jobs:
           fail=0
           while read -r sha; do
             [ -z "$sha" ] && continue
-            output=$(bash .github/scripts/classify-changes.sh "$sha" \
+            output=$(bash .vsdd-philosophies/.github/scripts/classify-changes.sh "$sha" \
               ${GLOBS:+--patterns "$GLOBS"})
             tests_only=$(grep '^tests-only=' <<<"$output" | cut -d= -f2)
             if [ "$tests_only" != "true" ]; then

--- a/.github/workflows/red-conditions-gate.yml
+++ b/.github/workflows/red-conditions-gate.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: s
-        uses: ./.github/actions/repo-shape
+        uses: sw2m/philosophies/.github/actions/repo-shape@main
 
   red-conditions:
     name: Red-conditions gate (3-clause)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,14 +52,41 @@ jobs:
 
   structural-sanity:
     name: MEMORY.md structural sanity
+    # Skip when consumer doesn't have a MEMORY.md — this check is
+    # philosophies-specific (asserts 9 Roman-numeral sections in the
+    # canonical doc) and not meaningful for repos that don't carry their
+    # own copy. The has-memory check is a cheap precondition.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Skip if no MEMORY.md
+        id: check
+        shell: bash
+        run: |
+          if [ -f MEMORY.md ]; then
+            echo "has-memory=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-memory=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No MEMORY.md in this repo. Structural sanity is philosophies-specific; skipping."
+          fi
+
+      # Fetch philosophies' check-memory-structure.sh for downstream
+      # callers that don't have it locally. (Only matters when has-memory
+      # is true, but the checkout is cheap and unconditional.)
+      - name: Fetch sw2m/philosophies scripts
+        if: steps.check.outputs.has-memory == 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: sw2m/philosophies
+          ref: main
+          path: .vsdd-philosophies
+
       - name: Assert all 9 numbered sections are present
-        run: bash .github/scripts/check-memory-structure.sh
+        if: steps.check.outputs.has-memory == 'true'
+        run: bash .vsdd-philosophies/.github/scripts/check-memory-structure.sh
 
   green-gate:
     name: Green Gate (§VIII tests on PR HEAD)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - id: shape
-        uses: ./.github/actions/repo-shape
+        uses: sw2m/philosophies/.github/actions/repo-shape@main
       - name: Detect runner + emit install/test commands
         id: runner
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Skip if no MEMORY.md
+        id: check
+        shell: bash
+        run: |
+          if [ -f MEMORY.md ]; then
+            echo "has-memory=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-memory=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No MEMORY.md in this repo. Lychee link check is philosophies-specific; skipping."
+          fi
+
       - name: Run lychee
+        if: steps.check.outputs.has-memory == 'true'
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-


### PR DESCRIPTION
## Summary

Closes #77.

Reusable VSDD workflows (called via \`workflow_call:\` from downstream sw2m repos like clesty) referenced their composite actions via the repo-relative \`./.github/actions/<name>\` form. When called from a downstream repo, that path resolved against the CALLER's checkout — and the actions don't exist there. Result: every workflow that uses \`repo-shape\`, \`gemini\`, \`claude\`, or the promote actions failed immediately on the consumer side with "Can't find <action>".

Convert all 13 relative action references to absolute paths (\`sw2m/philosophies/.github/actions/<name>@main\`).

## Trade-off

Philosophies' own PRs that modify a composite action no longer dogfood the modification before merge — the workflow fetches \`@main\`. Action-modifying PRs are a minority of changes; the single-PR-cycle loss is acceptable in exchange for the cross-repo reusability the \`## CI/CD\` section explicitly promised.

Surfaced concretely on sw2m/clesty#458.

## Test plan

- [ ] CI passes here.
- [ ] After merge, sw2m/clesty#458's CI re-runs — \`Detect repo shape\` succeeds, downstream reviewer jobs reach the agent steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)