### PR TITLE
hotfix: remove duplicate trust-github-actions-bot input declarations

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -11,7 +11,6 @@ inputs:
     description: "GitHub org whose members are allowed to invoke this agent. Non-members trigger a hard fail. Default sw2m."
     required: false
     default: "sw2m"
-  trust-github-actions-bot: {description: "When 'true', accept github-actions[bot] without org-membership check. Caller must validate safe context first. See #112.", required: false, default: 'false'}
   actor-override:
     description: |
       If set, validate this login against the org instead of the workflow

--- a/.github/actions/gemini/action.yml
+++ b/.github/actions/gemini/action.yml
@@ -10,7 +10,6 @@ inputs:
     description: "GitHub org whose members are allowed to invoke this agent. Non-members trigger a hard fail. Default sw2m."
     required: false
     default: "sw2m"
-  trust-github-actions-bot: {description: "When 'true', accept github-actions[bot] without org-membership check. Caller must validate safe context first. See #112.", required: false, default: 'false'}
   actor-override:
     description: |
       If set, validate this login against the org instead of the workflow

--- a/tests/issue-113-trust-signal-api.test.js
+++ b/tests/issue-113-trust-signal-api.test.js
@@ -236,12 +236,33 @@ test('trust-github-actions-bot token is grep-able in claude action', () => {
 // -----------------------------------------------------------------------------
 
 function extractInputBlock(content, name) {
-  // Match from "inputName:" to the next input at the same indentation level
-  // or end of inputs section. This is a simplified parser for YAML inputs.
-  const pattern = new RegExp(
-    `^([ \\t]*)${name}:([\\s\\S]*?)(?=^\\1[a-z-]+:|^[a-z]+:|$)`,
-    'm',
-  );
-  const match = content.match(pattern);
-  return match ? match[0] : null;
+  // Line-based scanner: locate the line declaring `name:` at some indent,
+  // then walk forward to the next line whose indent is <= the declaration
+  // indent and which itself starts a new YAML key. The original regex form
+  // collapsed to a single-line capture under the `m` flag because `$`
+  // matched end-of-line, not end-of-input.
+  const lines = content.split('\n');
+  const headerRe = new RegExp(`^([ \\t]*)${name}:`);
+  let startIdx = -1;
+  let indentLen = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(headerRe);
+    if (m) {
+      startIdx = i;
+      indentLen = m[1].length;
+      break;
+    }
+  }
+  if (startIdx === -1) return null;
+  const keyRe = /^([ \t]*)[A-Za-z_][A-Za-z0-9_-]*:/;
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    const m = lines[i].match(keyRe);
+    if (m && m[1].length <= indentLen) {
+      endIdx = i;
+      break;
+    }
+  }
+  return lines.slice(startIdx, endIdx).join('\n');
 }


### PR DESCRIPTION
## Summary

Hotfix. Removes the duplicate `trust-github-actions-bot` input on both gemini and claude composite actions.

PRs #119 and #121 both added the same input in different forms (inline + block). YAML rejects the duplicate at action-load time, breaking every workflow that consumes either composite action: issue-review, pr-review, ci-meta, promote-goal-to-tech, promote-tech-to-pr.

Surfaced as a "Set up job" failure on issue #126's Phase 1c review (`'trust-github-actions-bot' is already defined`). The bot pipeline is otherwise stop-the-world — it cannot self-fix because it uses the broken actions.

## Test plan

- [ ] Action.yml syntactic validity verified by gh action loader
- [ ] After merge: re-trigger issue-review on #126; expect green Phase 1c run

Closes #112-followup (no spec issue exists for this bug — it's the merge artifact of #119+#121, both of which already closed their parent specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)