### PR TITLE
hotfix: indent heredoc bodies inside YAML run-scalars

### DIFF
--- a/.github/workflows/red-conditions-gate.yml
+++ b/.github/workflows/red-conditions-gate.yml
@@ -151,12 +151,14 @@ jobs:
             echo "Marker already posted on this PR; skipping (one-way diode)."
             exit 0
           fi
-          # Per #129: spec mandates the trailing `\n` at end of body.
-          # Command substitution `$(printf ...)` would strip trailing
-          # newlines; use `--body-file -` with a heredoc instead.
-          gh pr comment "$PR" --body-file - <<'MARKER_EOF'
-<!-- vsdd-red-gate-cleared -->
-
-_Phase 2 conditions met. This marker latches; the bot will not revoke it._
-MARKER_EOF
+          # Per #129: spec mandates the trailing `\n` at end of body. The
+          # earlier `$(printf ...)` form stripped trailing newlines, and the
+          # subsequent unindented heredoc broke the YAML literal block
+          # scalar. This printf pipeline keeps every line at the YAML
+          # indent and preserves the trailing `\n` via `printf '%s\n'`.
+          {
+            printf '%s\n' '<!-- vsdd-red-gate-cleared -->'
+            printf '\n'
+            printf '%s\n' '_Phase 2 conditions met. This marker latches; the bot will not revoke it._'
+          } | gh pr comment "$PR" --body-file -
           echo "Posted Red-gate-cleared marker (token-only)."

--- a/.github/workflows/vsdd-brand.yml
+++ b/.github/workflows/vsdd-brand.yml
@@ -244,13 +244,13 @@ jobs:
 
           if [ "$BRAND" = "true" ]; then
             if [ "$count" -eq 0 ]; then
-              gh pr comment "$PR" --body-file - <<'BRAND_EOF'
-<!-- vsdd-opt-out-brand -->
-
-**VSDD opt-out / out-of-process** — this PR has been branded `vsdd:opt-out` by `github-actions[bot]`. Either every changed file is under `.github/` (whitelist-match, no test-discipline expected) OR the PR has impl content without an earned `Red-gate-cleared` marker (divergence from VSDD best-effort).
-
-The brand is informational; it does not block merge. It records, in a tamper-resistant location authored by the bot, that the PR is out-of-process under VSDD discipline.
-BRAND_EOF
+              {
+                printf '%s\n' '<!-- vsdd-opt-out-brand -->'
+                printf '\n'
+                printf '%s\n' '**VSDD opt-out / out-of-process** — this PR has been branded `vsdd:opt-out` by `github-actions[bot]`. Either every changed file is under `.github/` (whitelist-match, no test-discipline expected) OR the PR has impl content without an earned `Red-gate-cleared` marker (divergence from VSDD best-effort).'
+                printf '\n'
+                printf '%s\n' 'The brand is informational; it does not block merge. It records, in a tamper-resistant location authored by the bot, that the PR is out-of-process under VSDD discipline.'
+              } | gh pr comment "$PR" --body-file -
               echo "Posted vsdd:opt-out brand comment."
             elif [ "$count" -eq 1 ]; then
               echo "Brand comment already present (id=${existing_ids[0]}); leaving in place."


### PR DESCRIPTION
Closes #140-followup (no dedicated spec issue; this is a follow-up to #140, which is where I introduced the heredoc indentation bug).

## Summary

Both `red-conditions-gate.yml` and `vsdd-brand.yml` had bash quoted heredocs (`<<'XXX_EOF'`) whose bodies sat at column 0, terminating the YAML literal block scalar (`run: |`) early. GitHub's workflow validator marked both files invalid on every push — visible as failure runs at e.g. https://github.com/sw2m/philosophies/actions/runs/25269748335. The runner accepted them only because its parser is more permissive than the validator.

Replace each heredoc with an indented printf pipeline that stays inside the YAML scalar and preserves the trailing newline the markers require.

I introduced this bug myself in earlier PRs (#130-area) when switching from `$(printf ...)` (which strips trailing newlines) to a body-file heredoc to preserve `\n`. Memory updated: I reliably misindent YAML+heredoc combinations and should avoid the pattern entirely.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` parses both files cleanly post-fix (failed pre-fix at line 158 / line 248).
- [x] No semantic change to the marker or brand comment bodies — only the bash form changes.
- [ ] Push-event runs of both workflows on this branch should now show 0 failures (this PR's CI verifies).
- [ ] After merge, the stuck "Expected — Waiting" symptom on PR #124 should clear (the validator failure was masking the actual `red-conditions` job's run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
