### PR TITLE
fix(promote): Phase 1c verdict freshness gates on body-edit timestamp, not updated_at

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -103,17 +103,47 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
-          ISSUE_UPDATED: ${{ github.event.issue.updated_at }}
         shell: bash
         run: |
           set -euo pipefail
-          # Find the latest verdict marker per reviewer that github-actions[bot]
-          # posted AFTER the issue's last update. Both reviewers (gemini, claude)
-          # must be present and PASS.
+          # Per #93: gate verdict freshness against the issue's BODY-EDIT
+          # timestamp (`lastEditedAt`), not its `updated_at`. `updated_at`
+          # bumps on every field change — assignments, label changes,
+          # comment additions — including the very `assigned` event that
+          # fires this workflow. That made fresh verdicts always read as
+          # stale at validation time (since the assign timestamp post-
+          # dates them by definition), producing a structural race that
+          # made promotion impossible without admin override. Body edits
+          # are the ONLY change that can invalidate Phase 1c verdicts
+          # (the verdicts judge body content); gating on `lastEditedAt`
+          # gives the right reference. Falls back to `createdAt` when
+          # the body has never been edited since the issue opened.
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+          REF_AT=$(gh api graphql \
+            -f query='query($owner: String!, $name: String!, $num: Int!) {
+              repository(owner: $owner, name: $name) {
+                issue(number: $num) {
+                  lastEditedAt
+                  createdAt
+                }
+              }
+            }' \
+            -F owner="$OWNER" -F name="$NAME" -F num="$ISSUE" \
+            --jq '.data.repository.issue.lastEditedAt // .data.repository.issue.createdAt')
+          if [ -z "$REF_AT" ] || [ "$REF_AT" = "null" ]; then
+            echo "::error::Could not resolve body-edit timestamp for issue #${ISSUE}; refusing to evaluate verdict freshness."
+            echo "cleared=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          updated_epoch=$(date -d "$REF_AT" +%s)
+          echo "Phase 1c verdict-freshness reference: $REF_AT (epoch $updated_epoch); per #93 this is the body-edit timestamp, not updated_at."
+
+          # Find the latest verdict marker per reviewer that
+          # github-actions[bot] posted AFTER the issue's last body edit.
+          # Both reviewers (gemini, claude) must be present and PASS.
           comments=$(gh api -H "Accept: application/vnd.github+json" \
             "repos/${REPO}/issues/${ISSUE}/comments?per_page=100")
-
-          updated_epoch=$(date -d "$ISSUE_UPDATED" +%s)
 
           for reviewer in gemini claude; do
             # Each Phase 1c reviewer comment carries an HTML-comment-
@@ -151,7 +181,7 @@ jobs:
             created_at=$(jq -r '.created_at' <<<"$latest")
             created_epoch=$(date -d "$created_at" +%s)
             if [ "$created_epoch" -lt "$updated_epoch" ]; then
-              echo "::error::Phase 1c ${reviewer} verdict (${verdict}) is stale — posted at ${created_at}, issue updated at ${ISSUE_UPDATED}. Edit the issue body to re-trigger Phase 1c."
+              echo "::error::Phase 1c ${reviewer} verdict (${verdict}) is stale — posted at ${created_at}, issue body last edited at ${REF_AT}. Edit the issue body to re-trigger Phase 1c."
               echo "cleared=false" >> "$GITHUB_OUTPUT"
               exit 1
             fi
@@ -182,7 +212,7 @@ jobs:
             orch_created=$(jq -r '.created_at' <<<"$orch_latest")
             orch_epoch=$(date -d "$orch_created" +%s)
             # Only enforce when the orchestrator comment is fresh (not
-            # stale relative to the issue's last update).
+            # stale relative to the issue's last body edit, per #93).
             if [ "$orch_epoch" -ge "$updated_epoch" ] && [ "$orch_verdict" = "fail" ]; then
               echo "::error::Phase 1c orchestrator verdict is 'fail' at ${orch_created}. See the orchestrator comment for blocking concerns."
               echo "cleared=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -129,7 +129,7 @@ jobs:
                 }
               }
             }' \
-            -F owner="$OWNER" -F name="$NAME" -F num="$ISSUE" \
+            -f owner="$OWNER" -f name="$NAME" -F num="$ISSUE" \
             --jq '.data.repository.issue.lastEditedAt // .data.repository.issue.createdAt')
           if [ -z "$REF_AT" ] || [ "$REF_AT" = "null" ]; then
             echo "::error::Could not resolve body-edit timestamp for issue #${ISSUE}; refusing to evaluate verdict freshness."


### PR DESCRIPTION
Closes #93.

## Summary

`promote.yml`'s `phase-1c-clearance` step compared verdict-comment timestamps against `github.event.issue.updated_at` from the assign-event payload. `updated_at` bumps on every field change — assignments, labels, comment additions — **including the very `assigned` event that fires this workflow**.

Result: fresh verdicts (posted seconds before the assign) always read as stale (since the assign post-dates them by definition), so the gate failed even when the issue was correctly dual-passed. Promotion became structurally impossible without admin override across every recently-cleared spec (#144, #145, #155, #158 all hit this).

## Fix

Replace `updated_at` with the issue's `lastEditedAt` (via GraphQL). `lastEditedAt` bumps only when the issue body is edited — the ONLY change that can invalidate Phase 1c verdicts (the verdicts judge body content). Falls back to `createdAt` when the body has never been edited since the issue opened.

```diff
-          ISSUE_UPDATED: ${{ github.event.issue.updated_at }}
+          # (env var removed; resolved via GraphQL inside the run block)
```

The check's intent is preserved: a body edit invalidates prior verdicts and triggers `issue-review.yml`'s `edited` re-fire to produce fresh ones. What changes is the reference timestamp — assignments, labels, and comment additions no longer falsely invalidate verdicts.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` parses cleanly post-fix.
- [ ] After merge, re-fire promote on #145 and #158 (both currently dual-passed, both currently race-blocked); both should clear `phase-1c-clearance` and proceed to their respective `promote-goal-to-tech` / `promote-tech-to-pr` jobs.
- [ ] Verify a body-edit on a goal-spec invalidates verdicts as before (the check still fires when verdicts predate the body edit; only the reference timestamp source changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)