### PR TITLE
hotfix: agent-CLI timeout to prevent indefinite promote-tech-to-pr hangs

### DIFF
--- a/.github/actions/promote/promote-tech-to-pr/action.yml
+++ b/.github/actions/promote/promote-tech-to-pr/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Max retries per gate (Red, Green). 3 = up to 4 attempts each."
     required: false
     default: "3"
+  agent-timeout-seconds:
+    description: "Wall-clock timeout for each Claude Code CLI invocation. Hard cap that prevents indefinite hangs (e.g. an in-flight API call that never returns); on timeout the primary call is treated as failed and the fallback model retries. 900s = 15 min."
+    required: false
+    default: "900"
 
 runs:
   using: "composite"
@@ -192,26 +196,40 @@ runs:
         PR_NUMBER: ${{ steps.scaffold.outputs.pr-number }}
         DEFAULT_TEST_CMD: ${{ steps.runner.outputs.default-cmd }}
         MAX_RETRIES: ${{ inputs.max-retries }}
+        AGENT_TIMEOUT_SECONDS: ${{ inputs.agent-timeout-seconds }}
       run: |
         set -euo pipefail
 
+        # `timeout` exit code 124 means the wall-clock budget elapsed before
+        # the CLI returned — treat identically to a non-zero exit (engage
+        # fallback). Without this wrapper a stalled API call hangs the whole
+        # job for hours (observed in run 25299341730 → #175).
         invoke_claude() {
           local input="$1" output="$2"
           local primary="claude-opus-4-5" fallback="claude-sonnet-4-5"
           set +e
-          claude --print --model "$primary" \
+          timeout --signal=TERM --kill-after=30s "${AGENT_TIMEOUT_SECONDS}s" \
+            claude --print --model "$primary" \
             --allowed-tools "Bash Edit Write Read Glob Grep" \
             --permission-mode bypassPermissions \
             < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
           local rc=$?
-          if [ $rc -ne 0 ]; then
+          if [ $rc -eq 124 ]; then
+            echo "::warning::Phase agent: primary $primary timed out after ${AGENT_TIMEOUT_SECONDS}s; falling back to $fallback"
+          elif [ $rc -ne 0 ]; then
             echo "::warning::Phase agent: primary $primary exited $rc; falling back to $fallback"
             tail -50 ${RUNNER_TEMP}/claude-err.log
-            claude --print --model "$fallback" \
+          fi
+          if [ $rc -ne 0 ]; then
+            timeout --signal=TERM --kill-after=30s "${AGENT_TIMEOUT_SECONDS}s" \
+              claude --print --model "$fallback" \
               --allowed-tools "Bash Edit Write Read Glob Grep" \
               --permission-mode bypassPermissions \
               < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
             rc=$?
+            if [ $rc -eq 124 ]; then
+              echo "::warning::Phase agent: fallback $fallback also timed out after ${AGENT_TIMEOUT_SECONDS}s"
+            fi
           fi
           set -e
           return $rc
@@ -425,6 +443,7 @@ runs:
         PR_NUMBER: ${{ steps.scaffold.outputs.pr-number }}
         NO_RUNNER: ${{ steps.runner.outputs.no-runner }}
         MAX_RETRIES: ${{ inputs.max-retries }}
+        AGENT_TIMEOUT_SECONDS: ${{ inputs.agent-timeout-seconds }}
       run: |
         set -euo pipefail
 
@@ -432,19 +451,28 @@ runs:
           local input="$1" output="$2"
           local primary="claude-opus-4-5" fallback="claude-sonnet-4-5"
           set +e
-          claude --print --model "$primary" \
+          timeout --signal=TERM --kill-after=30s "${AGENT_TIMEOUT_SECONDS}s" \
+            claude --print --model "$primary" \
             --allowed-tools "Bash Edit Write Read Glob Grep" \
             --permission-mode bypassPermissions \
             < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
           local rc=$?
-          if [ $rc -ne 0 ]; then
+          if [ $rc -eq 124 ]; then
+            echo "::warning::Phase agent: primary $primary timed out after ${AGENT_TIMEOUT_SECONDS}s; falling back to $fallback"
+          elif [ $rc -ne 0 ]; then
             echo "::warning::Phase agent: primary $primary exited $rc; falling back to $fallback"
             tail -50 ${RUNNER_TEMP}/claude-err.log
-            claude --print --model "$fallback" \
+          fi
+          if [ $rc -ne 0 ]; then
+            timeout --signal=TERM --kill-after=30s "${AGENT_TIMEOUT_SECONDS}s" \
+              claude --print --model "$fallback" \
               --allowed-tools "Bash Edit Write Read Glob Grep" \
               --permission-mode bypassPermissions \
               < "$input" > "$output" 2>${RUNNER_TEMP}/claude-err.log
             rc=$?
+            if [ $rc -eq 124 ]; then
+              echo "::warning::Phase agent: fallback $fallback also timed out after ${AGENT_TIMEOUT_SECONDS}s"
+            fi
           fi
           set -e
           return $rc


### PR DESCRIPTION
## Summary

- Wraps both `invoke_claude` calls in `.github/actions/promote/promote-tech-to-pr/action.yml` with GNU coreutils `timeout`
- New input `agent-timeout-seconds` (default 900s = 15 min) caps each Claude Code CLI invocation
- On wall-clock timeout (exit 124) the primary's non-zero rc engages the existing fallback-model path; if the fallback also times out, the attempt is logged and counts toward the per-gate retry budget

## Why

Run [25299341730 / job 74163468507](https://github.com/sw2m/philosophies/actions/runs/25299341730/job/74163468507) hung for 60+ min on a single `claude --print` invocation in Phase 4 (the §VIII N/A path) — the CLI sat blocked on a network/API call that never returned, with no upstream timeout to cut it off. Until that runner was cancelled, no promote-tech-to-pr could progress; the in-progress concurrency lock would have blocked re-fires for the same issue.

This is a hotfix because:
- The fix is purely defensive (existing retry/fallback semantics are preserved; only the no-progress hang is bounded)
- Without it, every future promote-tech-to-pr run is at risk of the same indefinite hang on any agent-API hiccup
- The bot pipeline IS the path through which we'd normally promote a fix, so we'd otherwise hit the catch-22

## Test plan

- [ ] CI passes (`test.yml`, `pr-review.yml`, `ci-meta.yml`)
- [ ] After merge: re-fire promote on #174 (unassign+reassign anonhostpi); confirm new run completes within reasonable time AND that timeout warning surfaces if any phase ever hangs
- [ ] Spot-check logs of the next promote run to confirm `timeout`-wrapped invocations log expected warnings on simulated hang

Closes #177 (the broader timeout-discipline goal-spec). The hotfix bounds `promote-tech-to-pr` only; #177 tracks the generalized discipline across every agent invocation in CI.
