### PR TITLE
hotfix(ci-meta): broaden paths filter to .github/**

### DIFF
--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -121,6 +121,23 @@ jobs:
               cat "$f"
               echo "</action>"
             done
+            # Per #198: scripts/ and top-level .github docs (CLAUDE.md,
+            # labels.yml, etc.) shape the CI contract. Embed them so the
+            # reviewers can actually evaluate what the broadened trigger
+            # now fires on.
+            if [ -d .github/scripts ]; then
+              find .github/scripts -type f | sort | while read -r f; do
+                echo "<script path=\"$f\">"
+                cat "$f"
+                echo "</script>"
+              done
+            fi
+            for f in .github/*.md .github/*.yml; do
+              [ -f "$f" ] || continue
+              echo "<doc path=\"$f\">"
+              cat "$f"
+              echo "</doc>"
+            done
           } > eval-input.txt
           wc -l eval-input.txt
 
@@ -158,6 +175,11 @@ jobs:
             Read the canonical VSDD doc inside <vsdd-canonical> tags.
             Read each CI workflow file inside <workflow path="..."> tags.
             Read each composite action file inside <action path="..."> tags.
+            Read each CI helper script inside <script path="..."> tags
+            (these implement workflow logic invoked by `actions/github-script`,
+            inline `run:` blocks, or `github-deno` calls).
+            Read top-level `.github/` docs and config (CLAUDE.md, labels.yml,
+            etc.) inside <doc path="..."> tags.
 
             Repo-shape context (detected by `.github/actions/git/repo-shape`, which
             looks for package.json / deno.json / Cargo.toml / go.mod /
@@ -320,11 +342,14 @@ jobs:
 
             You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
 
-            The canonical VSDD doc, every CI workflow file, and every
-            composite action in this PR are EMBEDDED below in the same
-            message inside <vsdd-canonical>, <workflow path="...">, and
-            <action path="..."> tags. Do NOT look for files on disk; only
-            cite content that is present in the embedded text.
+            The canonical VSDD doc, every CI workflow file, every
+            composite action, every CI helper script under `.github/scripts/`,
+            and every top-level `.github/` doc/config (CLAUDE.md, labels.yml,
+            etc.) in this PR are EMBEDDED below in the same message inside
+            <vsdd-canonical>, <workflow path="...">, <action path="...">,
+            <script path="...">, and <doc path="..."> tags. Do NOT look for
+            files on disk; only cite content that is present in the embedded
+            text.
 
             Repo-shape context (detected by `.github/actions/git/repo-shape`,
             which looks for package.json / deno.json / Cargo.toml / go.mod

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -18,8 +18,11 @@ on:
     # skipped at job level via the `if: ... draft != true` guard below.
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
+      # Broadened from explicit (workflows + actions + MEMORY.md) to all of
+      # .github/** per #198: scripts/, prompts/, CLAUDE.md, labels.yml etc.
+      # are all CI-meta-relevant — anything under .github/ shapes the CI
+      # contract and should re-trigger this review.
+      - ".github/**"
       - "MEMORY.md"
   workflow_call:
     inputs:

--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -109,34 +109,16 @@ jobs:
             cat memory-canonical.md
             echo "</vsdd-canonical>"
             echo ""
-            for f in .github/workflows/*.yml; do
-              [ -f "$f" ] || continue
-              echo "<workflow path=\"$f\">"
+            # Per #198: trigger is .github/** and the eval payload mirrors it.
+            # Recursive so any new sub-tree under .github/ (e.g. prompts/)
+            # auto-inherits coverage — the path filter and the embed loop
+            # stay in sync without per-directory edits to this workflow.
+            # Action helpers (e.g. .github/actions/*/runner.ts) are also
+            # picked up here, not just the action.yml manifests.
+            find .github -type f | sort | while read -r f; do
+              echo "<file path=\"$f\">"
               cat "$f"
-              echo "</workflow>"
-            done
-            for f in .github/actions/*/*/action.yml; do
-              [ -f "$f" ] || continue
-              echo "<action path=\"$f\">"
-              cat "$f"
-              echo "</action>"
-            done
-            # Per #198: scripts/ and top-level .github docs (CLAUDE.md,
-            # labels.yml, etc.) shape the CI contract. Embed them so the
-            # reviewers can actually evaluate what the broadened trigger
-            # now fires on.
-            if [ -d .github/scripts ]; then
-              find .github/scripts -type f | sort | while read -r f; do
-                echo "<script path=\"$f\">"
-                cat "$f"
-                echo "</script>"
-              done
-            fi
-            for f in .github/*.md .github/*.yml; do
-              [ -f "$f" ] || continue
-              echo "<doc path=\"$f\">"
-              cat "$f"
-              echo "</doc>"
+              echo "</file>"
             done
           } > eval-input.txt
           wc -l eval-input.txt
@@ -173,13 +155,14 @@ jobs:
             You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
 
             Read the canonical VSDD doc inside <vsdd-canonical> tags.
-            Read each CI workflow file inside <workflow path="..."> tags.
-            Read each composite action file inside <action path="..."> tags.
-            Read each CI helper script inside <script path="..."> tags
-            (these implement workflow logic invoked by `actions/github-script`,
-            inline `run:` blocks, or `github-deno` calls).
-            Read top-level `.github/` docs and config (CLAUDE.md, labels.yml,
-            etc.) inside <doc path="..."> tags.
+            Every file under `.github/` is embedded inside a single
+            <file path="..."> tag with its repo-relative path. Categories
+            you can expect (treat them by file path, not tag name):
+            workflows (`.github/workflows/*.yml`), composite actions
+            (`.github/actions/<category>/<name>/action.yml`) and their
+            helpers (`runner.ts`, `cli.js`, etc.), CI helper scripts
+            (`.github/scripts/`), and top-level `.github/` docs and config
+            (CLAUDE.md per #152, labels.yml, etc.).
 
             Repo-shape context (detected by `.github/actions/git/repo-shape`, which
             looks for package.json / deno.json / Cargo.toml / go.mod /
@@ -342,14 +325,14 @@ jobs:
 
             You are reviewing CI workflows against VSDD (Verified Spec-Driven Development).
 
-            The canonical VSDD doc, every CI workflow file, every
-            composite action, every CI helper script under `.github/scripts/`,
-            and every top-level `.github/` doc/config (CLAUDE.md, labels.yml,
-            etc.) in this PR are EMBEDDED below in the same message inside
-            <vsdd-canonical>, <workflow path="...">, <action path="...">,
-            <script path="...">, and <doc path="..."> tags. Do NOT look for
-            files on disk; only cite content that is present in the embedded
-            text.
+            The canonical VSDD doc is embedded inside <vsdd-canonical>
+            tags. Every file under `.github/` is embedded inside a single
+            <file path="..."> tag with its repo-relative path — workflows,
+            composite actions and their helpers (runner.ts, cli.js, etc.),
+            CI helper scripts under `.github/scripts/`, and top-level
+            `.github/` docs/config (CLAUDE.md per #152, labels.yml, etc.).
+            Do NOT look for files on disk; only cite content that is
+            present in the embedded text.
 
             Repo-shape context (detected by `.github/actions/git/repo-shape`,
             which looks for package.json / deno.json / Cargo.toml / go.mod


### PR DESCRIPTION
Closes #198

## Summary

`ci-meta.yml`'s `paths:` filter explicitly listed three paths:

```
.github/workflows/**
.github/actions/**
MEMORY.md
```

Anything else under `.github/` — `scripts/`, `CLAUDE.md` (per #152), `labels.yml`, future `prompts/` (#181/#183) — fell through and skipped CI-meta despite shaping the CI contract just as much as workflows do.

## Symptom

PR #188 modifies only `.github/scripts/**`. ci-meta.yml never enqueues a run for it → its 3 jobs (`Gemini VSDD CI evaluation`, `Claude VSDD CI evaluation`, `Consensus + open issues for gaps`) never report a status → the `main protection` ruleset shows them as "Expected — Waiting for status to be reported" indefinitely → merge is blocked.

## Fix

Collapse to:

```
.github/**
MEMORY.md
```

Anything CI-meta-relevant lives under those two trees by repo convention. New sub-trees added later (`.github/prompts/`, etc.) inherit coverage automatically — no future "I added a new directory and ci-meta forgot to fire" edits.

## Test plan

- [ ] CI on this PR exercises the new filter (this PR touches `.github/workflows/ci-meta.yml`, which matches both the OLD and NEW filter, so ci-meta.yml fires either way — that's the smoke test).
- [ ] Once merged, re-trigger PR #188 (and #189-#194) and confirm the 3 ci-meta required checks now report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)