### PR TITLE
feat(vsdd): unified HTML-comment frontmatter parser

### DIFF
--- a/.github/scripts/vsdd/frontmatter.ts
+++ b/.github/scripts/vsdd/frontmatter.ts
@@ -36,10 +36,99 @@
 //     (b) => isMapping(b) && "vsdd-phase-3-aggregate" in b,
 //   )?.["vsdd-phase-3-aggregate"];
 
-import { parse as parseYAML } from "jsr:@std/yaml@^1";
+import { parse as yaml } from "jsr:@std/yaml@^1";
 
 const OPEN = "<!--";
 const CLOSE = "-->";
+
+/** State engine: walks `body` from left to right, pulling out each
+ *  well-formed `<!-- ... -->` block and parsing its content as YAML.
+ *  Mutable state is the cursor (`pos`) and the accumulator (`blocks`);
+ *  pure helpers (`content`, `dedent`, `leading`) live as statics. */
+class Parse {
+  private body: string;
+  private pos = 0;
+  private blocks: unknown[] = [];
+
+  constructor(body: string) {
+    this.body = body;
+  }
+
+  /** Drive the engine to exhaustion and return all parsed blocks. */
+  run(): unknown[] {
+    while (this.step()) { /* advance */ }
+    return this.blocks;
+  }
+
+  /** One step: scan from the cursor for the next `<!--...-->`, classify it,
+   *  push the parsed value if non-empty, advance the cursor. Returns
+   *  false when no further block exists. */
+  private step(): boolean {
+    const start = this.body.indexOf(OPEN, this.pos);
+    if (start === -1) return false;
+    const end = this.body.indexOf(CLOSE, start + OPEN.length);
+    if (end === -1) return false;
+    this.pos = end + CLOSE.length;
+
+    const value = Parse.content(this.body.slice(start + OPEN.length, end));
+    if (value !== null && value !== undefined) this.blocks.push(value);
+    return true;
+  }
+
+  /** Classify the raw text between `<!--` and `-->` as inline or block,
+   *  validate the wrapper-line exclusivity rule, and parse as YAML.
+   *  Returns null for malformed shapes or empty content. */
+  static content(raw: string): unknown {
+    if (!raw.includes("\n")) {
+      const trimmed = raw.trim();
+      return trimmed === "" ? null : yaml(trimmed);
+    }
+
+    const head = raw.indexOf("\n");
+    const tail = raw.lastIndexOf("\n");
+    if (head >= tail) return null;
+    if (raw.slice(0, head).trim() !== "") return null;
+    if (raw.slice(tail + 1).trim() !== "") return null;
+
+    const dedented = Parse.dedent(raw.slice(head + 1, tail));
+    return dedented === "" ? null : yaml(dedented);
+  }
+
+  /** Strip the leading indentation common to every non-blank line.
+   *  Whitespace-only lines are exempt. Throws if any non-blank line has
+   *  SHORTER indent than the first non-blank line — that indicates a
+   *  broken block, not a YAML structure the parser would silently
+   *  mishandle. */
+  static dedent(block: string): string {
+    const lines = block.split("\n");
+
+    let indent = -1;
+    for (const line of lines) {
+      if (line.trim() === "") continue;
+      indent = Parse.leading(line);
+      break;
+    }
+    if (indent === -1) return "";
+
+    return lines.map((line) => {
+      if (line.trim() === "") return "";
+      const n = Parse.leading(line);
+      if (n < indent) {
+        throw new Error(
+          `frontmatter: line "${line}" has ${n} leading whitespace chars; first non-blank line had ${indent}`,
+        );
+      }
+      return line.slice(indent);
+    }).join("\n");
+  }
+
+  /** Count leading space and tab characters on a line. */
+  static leading(line: string): number {
+    let n = 0;
+    while (n < line.length && (line[n] === " " || line[n] === "\t")) n++;
+    return n;
+  }
+}
 
 /** Parse every well-formed HTML-comment metadata block in `body`, in source
  *  order. Each block's content is parsed as YAML and pushed to the result.
@@ -50,77 +139,5 @@ const CLOSE = "-->";
  *  Discrimination between blocks (which one is "mine"?) is the caller's
  *  job — filter the returned array by whatever convention the emitter uses. */
 export function parse(body: string): unknown[] {
-  const blocks: unknown[] = [];
-  let i = 0;
-  while (i < body.length) {
-    const start = body.indexOf(OPEN, i);
-    if (start === -1) break;
-    const end = body.indexOf(CLOSE, start + OPEN.length);
-    if (end === -1) break;
-    i = end + CLOSE.length;
-
-    const value = parseContent(body.slice(start + OPEN.length, end));
-    if (value !== null && value !== undefined) blocks.push(value);
-  }
-  return blocks;
-}
-
-/** Parse the raw text between `<!--` and `-->`. Determines inline vs. block
- *  form, validates the wrapper-line exclusivity rule, and returns the parsed
- *  YAML value (or null if the shape is malformed or content is empty). */
-function parseContent(raw: string): unknown {
-  // Inline form: no newlines anywhere between wrappers.
-  if (!raw.includes("\n")) {
-    const trimmed = raw.trim();
-    return trimmed === "" ? null : parseYAML(trimmed);
-  }
-
-  // Block form: text between `<!--` and the first newline must be
-  // whitespace-only (else content is sharing a line with `<!--`); same
-  // for text between the last newline and `-->`. Need at least two
-  // newlines so there's room for a body line between them.
-  const firstNL = raw.indexOf("\n");
-  const lastNL = raw.lastIndexOf("\n");
-  if (firstNL >= lastNL) return null;
-  if (raw.slice(0, firstNL).trim() !== "") return null;
-  if (raw.slice(lastNL + 1).trim() !== "") return null;
-
-  const inner = raw.slice(firstNL + 1, lastNL);
-  const dedented = dedent(inner);
-  return dedented === "" ? null : parseYAML(dedented);
-}
-
-/** Strip the leading indentation common to every non-blank line in a block.
- *  Whitespace-only lines are exempt (they don't constrain or violate the
- *  indent). Throws if any non-blank line has SHORTER indent than the
- *  first non-blank line — that indicates a broken block, not a YAML
- *  structure the parser would silently mishandle. */
-function dedent(block: string): string {
-  const lines = block.split("\n");
-
-  let indent = -1;
-  for (const line of lines) {
-    if (line.trim() === "") continue;
-    indent = leadingWS(line);
-    break;
-  }
-  if (indent === -1) return "";
-
-  return lines.map((line) => {
-    if (line.trim() === "") return "";
-    const leading = leadingWS(line);
-    if (leading < indent) {
-      throw new Error(
-        `frontmatter: line "${line}" has ${leading} leading whitespace chars; first non-blank line had ${indent}`,
-      );
-    }
-    return line.slice(indent);
-  }).join("\n");
-}
-
-/** Count leading space and tab characters on a line. */
-function leadingWS(line: string): number {
-  let n = 0;
-  while (n < line.length && (line[n] === " " || line[n] === "\t")) n++;
-  return n;
+  return new Parse(body).run();
 }

--- a/.github/scripts/vsdd/frontmatter.ts
+++ b/.github/scripts/vsdd/frontmatter.ts
@@ -38,35 +38,56 @@
 
 import { parse as parseYAML } from "jsr:@std/yaml@^1";
 
-/** Singleton regex matching every well-formed `<!-- ... -->` block in a body.
- *
- *  Two alternatives, two capture groups:
- *  - Group 1 (block form): wrapper-line whitespace must be tab/space only
- *    (excluding `\n`), forcing `<!--` and `-->` each to sit alone on their
- *    line. Content is non-empty (`+?` lazy).
- *  - Group 2 (inline form): content contains no newlines, forcing the
- *    entire match onto a single line. Non-empty.
- *
- *  Mismatched shapes (e.g., `<!-- foo\n-->`, `<!--\nfoo-->`, `<!---->`)
- *  match neither alternative and are silently skipped. */
-const FRONTMATTER_RE = /<!--(?:[ \t]*\n([\s\S]+?)\n[ \t]*|([^\n]+?))-->/g;
+const OPEN = "<!--";
+const CLOSE = "-->";
 
 /** Parse every well-formed HTML-comment metadata block in `body`, in source
  *  order. Each block's content is parsed as YAML and pushed to the result.
- *  Blocks whose content parses to null/undefined (whitespace-only, empty
- *  YAML document) are skipped silently.
+ *  Blocks whose content is empty (whitespace-only, or empty YAML) are
+ *  skipped silently, as are malformed shapes that fit neither inline nor
+ *  block form.
  *
- *  Discrimination between blocks (which one is "mine"?) is the caller's job
- *  — filter the returned array by whatever convention the emitter uses. */
+ *  Discrimination between blocks (which one is "mine"?) is the caller's
+ *  job — filter the returned array by whatever convention the emitter uses. */
 export function parse(body: string): unknown[] {
   const blocks: unknown[] = [];
-  for (const m of body.matchAll(FRONTMATTER_RE)) {
-    const content = m[1] !== undefined ? dedent(m[1]) : m[2].trim();
-    if (content === "") continue;
-    const value = parseYAML(content);
+  let i = 0;
+  while (i < body.length) {
+    const start = body.indexOf(OPEN, i);
+    if (start === -1) break;
+    const end = body.indexOf(CLOSE, start + OPEN.length);
+    if (end === -1) break;
+    i = end + CLOSE.length;
+
+    const value = parseContent(body.slice(start + OPEN.length, end));
     if (value !== null && value !== undefined) blocks.push(value);
   }
   return blocks;
+}
+
+/** Parse the raw text between `<!--` and `-->`. Determines inline vs. block
+ *  form, validates the wrapper-line exclusivity rule, and returns the parsed
+ *  YAML value (or null if the shape is malformed or content is empty). */
+function parseContent(raw: string): unknown {
+  // Inline form: no newlines anywhere between wrappers.
+  if (!raw.includes("\n")) {
+    const trimmed = raw.trim();
+    return trimmed === "" ? null : parseYAML(trimmed);
+  }
+
+  // Block form: text between `<!--` and the first newline must be
+  // whitespace-only (else content is sharing a line with `<!--`); same
+  // for text between the last newline and `-->`. Need at least two
+  // newlines so there's room for a body line between them.
+  const firstNL = raw.indexOf("\n");
+  const lastNL = raw.lastIndexOf("\n");
+  if (firstNL >= lastNL) return null;
+  if (raw.slice(0, firstNL).trim() !== "") return null;
+  if (raw.slice(lastNL + 1).trim() !== "") return null;
+
+  const inner = raw.slice(firstNL + 1, lastNL);
+  const dedented = dedent(inner);
+  return dedented === "" ? null : parseYAML(dedented);
 }
 
 /** Strip the leading indentation common to every non-blank line in a block.
@@ -80,19 +101,26 @@ function dedent(block: string): string {
   let indent = -1;
   for (const line of lines) {
     if (line.trim() === "") continue;
-    indent = line.match(/^(\s*)/)![1].length;
+    indent = leadingWS(line);
     break;
   }
   if (indent === -1) return "";
 
   return lines.map((line) => {
     if (line.trim() === "") return "";
-    const leading = line.match(/^(\s*)/)![1].length;
+    const leading = leadingWS(line);
     if (leading < indent) {
       throw new Error(
-        `frontmatter: line "${line}" has ${leading} leading spaces; first non-blank line had ${indent}`,
+        `frontmatter: line "${line}" has ${leading} leading whitespace chars; first non-blank line had ${indent}`,
       );
     }
     return line.slice(indent);
   }).join("\n");
+}
+
+/** Count leading space and tab characters on a line. */
+function leadingWS(line: string): number {
+  let n = 0;
+  while (n < line.length && (line[n] === " " || line[n] === "\t")) n++;
+  return n;
 }

--- a/.github/scripts/vsdd/frontmatter.ts
+++ b/.github/scripts/vsdd/frontmatter.ts
@@ -1,82 +1,91 @@
 // VSDD HTML-comment frontmatter parser. Replaces the per-context regex
 // implementations scattered in phase-1c-budget.js, phase-1c-cardinality.js,
-// vsdd-brand.js, and aggregate.ts (#186) — all of which parse the same
-// canonical block shape but with subtle regex divergence between them.
+// vsdd-brand.js, and aggregate.ts (#186) — all of which parse near-identical
+// block shapes with subtle regex divergence between them.
 //
-// Three canonical shapes (used across all VSDD machine-readable comments):
+// Two canonical shapes (HTML comment IS the marker — no header tokens):
 //
-//   <!-- {token} -->                              (marker; no body)
-//   <!-- {token}                                  (multiline; empty body)
-//   -->
-//   <!-- {token}                                  (multiline; YAML body)
-//   {YAML content}
+//   <!-- ...content on same line... -->         (inline; whole match on one line)
+//   <!--                                        (block; wrappers alone on their lines)
+//   ...content lines...
 //   -->
 //
-// The body, when present, is parsed as YAML — supports nested structure,
-// scalars typed by YAML semantics (numbers, booleans, nulls), arrays, etc.
-// The previous flat-regex parsers stringified everything; consumers
-// migrating to this utility may need to adapt to typed values.
+// The wrappers themselves are exclusive: `<!--` may only have non-whitespace
+// after it on a line that ALSO has `-->`; same for `-->`. Mixed shapes like
+//   <!-- token
+//   body
+//   -->
+// silently do NOT match — neither inline nor block — and are ignored.
 //
-// Tokens are listed in `symbols.yaml` under `frontmatter-tokens`
-// (e.g. `vsdd-phase-1c`, `vsdd-phase-3`, `vsdd-opt-out-brand`,
-// `vsdd-canonical`). Callers pass the literal token; the parser captures
-// it via the singleton regex below and filters by string match.
+// Content is parsed as YAML. Inline form parses any one-line YAML value
+// (string scalar, flow-array `[a, b]`, flow-mapping `{a: 1}`); block form
+// parses multiline YAML (typically a mapping). Discrimination between
+// blocks is the caller's job — typically one of:
 //
-// Consumers import as a namespace:
+//   1. inline marker scalar: `<!-- vsdd-opt-out-brand -->` → "vsdd-opt-out-brand"
+//   2. kv-discrimination:    `<!-- vsdd-phase-3: { state: clear } -->`
+//                            → { "vsdd-phase-3": { state: "clear" } }
+//   3. field-discrimination: `<!-- {phase: 3, kind: verdict, ...} -->`
+//                            → { phase: 3, kind: "verdict", ... }
+//
+// Consumer pattern:
 //
 //   import * as frontmatter from "../vsdd/frontmatter.ts";
-//   const fields = frontmatter.parse("vsdd-phase-3", body);
-//   const all = frontmatter.find("vsdd-phase-1c", body);
+//   const blocks = frontmatter.parse(body);
+//   const verdict = blocks.find(
+//     (b) => isMapping(b) && "vsdd-phase-3-aggregate" in b,
+//   )?.["vsdd-phase-3-aggregate"];
 
 import { parse as parseYAML } from "jsr:@std/yaml@^1";
 
-/** Singleton regex matching ALL `<!-- {token} ... -->` blocks in a body.
- *  Capture group 1 is the token; capture group 2 is the YAML body if
- *  present, undefined otherwise (marker-style with no body). */
-const FRONTMATTER_RE = /<!--\s*([\w-]+)(?:\s*\n([\s\S]*?)\n)?\s*-->/g;
-
-/** Parse the FIRST frontmatter block matching the given token from a body.
- *  Returns the parsed YAML mapping, or null if no matching block exists.
- *  Marker-style blocks (no body) return an empty mapping `{}`. */
-export function parse(token: string, body: string): Record<string, unknown> | null {
-  for (const m of body.matchAll(FRONTMATTER_RE)) {
-    if (m[1] === token) return parseBlock(m[2]);
-  }
-  return null;
-}
-
-/** Find ALL frontmatter blocks matching the given token in a body, in source
- *  order. Returns an array (possibly empty) of parsed YAML mappings.
- *  Marker-style blocks contribute empty mappings to the array. */
-export function find(token: string, body: string): Record<string, unknown>[] {
-  return Array.from(body.matchAll(FRONTMATTER_RE))
-    .filter((m) => m[1] === token)
-    .map((m) => parseBlock(m[2]));
-}
-
-/** Dedent the block (strip the leading indentation common to every non-blank
- *  line — typically the first non-blank line's indent), then parse as YAML.
- *  Throws if any non-blank line has SHORTER indentation than the first
- *  non-blank line — that indicates a broken block, not a YAML structure
- *  the parser would silently mishandle.
+/** Singleton regex matching every well-formed `<!-- ... -->` block in a body.
  *
- *  When `block` is undefined or all-blank, returns an empty mapping. */
-function parseBlock(block: string | undefined): Record<string, unknown> {
-  if (!block) return {};
+ *  Two alternatives, two capture groups:
+ *  - Group 1 (block form): wrapper-line whitespace must be tab/space only
+ *    (excluding `\n`), forcing `<!--` and `-->` each to sit alone on their
+ *    line. Content is non-empty (`+?` lazy).
+ *  - Group 2 (inline form): content contains no newlines, forcing the
+ *    entire match onto a single line. Non-empty.
+ *
+ *  Mismatched shapes (e.g., `<!-- foo\n-->`, `<!--\nfoo-->`, `<!---->`)
+ *  match neither alternative and are silently skipped. */
+const FRONTMATTER_RE = /<!--(?:[ \t]*\n([\s\S]+?)\n[ \t]*|([^\n]+?))-->/g;
+
+/** Parse every well-formed HTML-comment metadata block in `body`, in source
+ *  order. Each block's content is parsed as YAML and pushed to the result.
+ *  Blocks whose content parses to null/undefined (whitespace-only, empty
+ *  YAML document) are skipped silently.
+ *
+ *  Discrimination between blocks (which one is "mine"?) is the caller's job
+ *  — filter the returned array by whatever convention the emitter uses. */
+export function parse(body: string): unknown[] {
+  const blocks: unknown[] = [];
+  for (const m of body.matchAll(FRONTMATTER_RE)) {
+    const content = m[1] !== undefined ? dedent(m[1]) : m[2].trim();
+    if (content === "") continue;
+    const value = parseYAML(content);
+    if (value !== null && value !== undefined) blocks.push(value);
+  }
+  return blocks;
+}
+
+/** Strip the leading indentation common to every non-blank line in a block.
+ *  Whitespace-only lines are exempt (they don't constrain or violate the
+ *  indent). Throws if any non-blank line has SHORTER indent than the
+ *  first non-blank line — that indicates a broken block, not a YAML
+ *  structure the parser would silently mishandle. */
+function dedent(block: string): string {
   const lines = block.split("\n");
 
-  // Find indent of first non-blank line. If all-blank, return empty mapping.
   let indent = -1;
   for (const line of lines) {
     if (line.trim() === "") continue;
     indent = line.match(/^(\s*)/)![1].length;
     break;
   }
-  if (indent === -1) return {};
+  if (indent === -1) return "";
 
-  // Dedent: strip `indent` leading characters from each non-blank line.
-  // Throw if any non-blank line has less leading whitespace than the first.
-  const dedented = lines.map((line) => {
+  return lines.map((line) => {
     if (line.trim() === "") return "";
     const leading = line.match(/^(\s*)/)![1].length;
     if (leading < indent) {
@@ -85,14 +94,5 @@ function parseBlock(block: string | undefined): Record<string, unknown> {
       );
     }
     return line.slice(indent);
-  });
-
-  const parsed = parseYAML(dedented.join("\n"));
-  if (parsed === null || parsed === undefined) return {};
-  if (typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      `frontmatter: YAML content is not a mapping (got ${Array.isArray(parsed) ? "array" : typeof parsed})`,
-    );
-  }
-  return parsed as Record<string, unknown>;
+  }).join("\n");
 }

--- a/.github/scripts/vsdd/frontmatter.ts
+++ b/.github/scripts/vsdd/frontmatter.ts
@@ -1,0 +1,69 @@
+// VSDD HTML-comment frontmatter parser. Replaces the per-context regex
+// implementations scattered in phase-1c-budget.js, phase-1c-cardinality.js,
+// vsdd-brand.js, and aggregate.ts (#186) — all of which parse the same
+// canonical block shape but with subtle regex divergence between them.
+//
+// Canonical shape (used across all VSDD machine-readable comments):
+//
+//   <!-- {token}
+//   key: value
+//   key: value
+//   -->
+//
+// Tokens are listed in `symbols.yaml` under `frontmatter-tokens`
+// (e.g. `vsdd-phase-1c`, `vsdd-phase-3`, `vsdd-opt-out-brand`,
+// `vsdd-canonical`). This utility takes the literal token string from the
+// caller; it doesn't reach into the catalog itself.
+//
+// Consumers import as a namespace:
+//
+//   import * as frontmatter from "../vsdd/frontmatter.ts";
+//   const fields = frontmatter.parse("vsdd-phase-3", body);
+//   const all = frontmatter.find("vsdd-phase-1c", body);
+
+/** Parse the FIRST frontmatter block matching the given token from a body.
+ *  Returns the key→value map, or null if no matching block exists.
+ *
+ *  Field values are trimmed; keys must be `[\w-]+`. Lines that don't match
+ *  the `key: value` shape are silently skipped (allows blank lines or
+ *  comments inside the block). */
+export function parse(token: string, body: string): Record<string, string> | null {
+  const re = blockRegex(token, false);
+  const match = body.match(re);
+  if (!match) return null;
+  return parseFields(match[1]);
+}
+
+/** Find ALL frontmatter blocks matching the given token in a body, in source
+ *  order. Useful when a comment carries multiple structured payloads.
+ *  Returns an array (possibly empty) of key→value maps. */
+export function find(token: string, body: string): Record<string, string>[] {
+  const re = blockRegex(token, true);
+  const out: Record<string, string>[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    out.push(parseFields(m[1]));
+  }
+  return out;
+}
+
+/** Build the regex matching `<!-- {token}\n...\n-->`. Token is regex-escaped
+ *  so callers pass plain strings without worrying about metacharacters. */
+function blockRegex(token: string, global: boolean): RegExp {
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const flags = global ? "gm" : "m";
+  return new RegExp(
+    `<!--\\s*${escaped}\\s*\\n([\\s\\S]*?)\\n\\s*-->`,
+    flags,
+  );
+}
+
+/** Parse `key: value` lines from a frontmatter block's interior. */
+function parseFields(block: string): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/^\s*([\w-]+):\s*(.*?)\s*$/);
+    if (m) fields[m[1]] = m[2];
+  }
+  return fields;
+}

--- a/.github/scripts/vsdd/frontmatter.ts
+++ b/.github/scripts/vsdd/frontmatter.ts
@@ -3,17 +3,24 @@
 // vsdd-brand.js, and aggregate.ts (#186) — all of which parse the same
 // canonical block shape but with subtle regex divergence between them.
 //
-// Canonical shape (used across all VSDD machine-readable comments):
+// Three canonical shapes (used across all VSDD machine-readable comments):
 //
-//   <!-- {token}
-//   key: value
-//   key: value
+//   <!-- {token} -->                              (marker; no body)
+//   <!-- {token}                                  (multiline; empty body)
 //   -->
+//   <!-- {token}                                  (multiline; YAML body)
+//   {YAML content}
+//   -->
+//
+// The body, when present, is parsed as YAML — supports nested structure,
+// scalars typed by YAML semantics (numbers, booleans, nulls), arrays, etc.
+// The previous flat-regex parsers stringified everything; consumers
+// migrating to this utility may need to adapt to typed values.
 //
 // Tokens are listed in `symbols.yaml` under `frontmatter-tokens`
 // (e.g. `vsdd-phase-1c`, `vsdd-phase-3`, `vsdd-opt-out-brand`,
-// `vsdd-canonical`). This utility takes the literal token string from the
-// caller; it doesn't reach into the catalog itself.
+// `vsdd-canonical`). Callers pass the literal token; the parser captures
+// it via the singleton regex below and filters by string match.
 //
 // Consumers import as a namespace:
 //
@@ -21,49 +28,71 @@
 //   const fields = frontmatter.parse("vsdd-phase-3", body);
 //   const all = frontmatter.find("vsdd-phase-1c", body);
 
+import { parse as parseYAML } from "jsr:@std/yaml@^1";
+
+/** Singleton regex matching ALL `<!-- {token} ... -->` blocks in a body.
+ *  Capture group 1 is the token; capture group 2 is the YAML body if
+ *  present, undefined otherwise (marker-style with no body). */
+const FRONTMATTER_RE = /<!--\s*([\w-]+)(?:\s*\n([\s\S]*?)\n)?\s*-->/g;
+
 /** Parse the FIRST frontmatter block matching the given token from a body.
- *  Returns the key→value map, or null if no matching block exists.
- *
- *  Field values are trimmed; keys must be `[\w-]+`. Lines that don't match
- *  the `key: value` shape are silently skipped (allows blank lines or
- *  comments inside the block). */
-export function parse(token: string, body: string): Record<string, string> | null {
-  const re = blockRegex(token, false);
-  const match = body.match(re);
-  if (!match) return null;
-  return parseFields(match[1]);
+ *  Returns the parsed YAML mapping, or null if no matching block exists.
+ *  Marker-style blocks (no body) return an empty mapping `{}`. */
+export function parse(token: string, body: string): Record<string, unknown> | null {
+  for (const m of body.matchAll(FRONTMATTER_RE)) {
+    if (m[1] === token) return parseBlock(m[2]);
+  }
+  return null;
 }
 
 /** Find ALL frontmatter blocks matching the given token in a body, in source
- *  order. Useful when a comment carries multiple structured payloads.
- *  Returns an array (possibly empty) of key→value maps. */
-export function find(token: string, body: string): Record<string, string>[] {
-  const re = blockRegex(token, true);
-  const out: Record<string, string>[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(body)) !== null) {
-    out.push(parseFields(m[1]));
-  }
-  return out;
+ *  order. Returns an array (possibly empty) of parsed YAML mappings.
+ *  Marker-style blocks contribute empty mappings to the array. */
+export function find(token: string, body: string): Record<string, unknown>[] {
+  return Array.from(body.matchAll(FRONTMATTER_RE))
+    .filter((m) => m[1] === token)
+    .map((m) => parseBlock(m[2]));
 }
 
-/** Build the regex matching `<!-- {token}\n...\n-->`. Token is regex-escaped
- *  so callers pass plain strings without worrying about metacharacters. */
-function blockRegex(token: string, global: boolean): RegExp {
-  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const flags = global ? "gm" : "m";
-  return new RegExp(
-    `<!--\\s*${escaped}\\s*\\n([\\s\\S]*?)\\n\\s*-->`,
-    flags,
-  );
-}
+/** Dedent the block (strip the leading indentation common to every non-blank
+ *  line — typically the first non-blank line's indent), then parse as YAML.
+ *  Throws if any non-blank line has SHORTER indentation than the first
+ *  non-blank line — that indicates a broken block, not a YAML structure
+ *  the parser would silently mishandle.
+ *
+ *  When `block` is undefined or all-blank, returns an empty mapping. */
+function parseBlock(block: string | undefined): Record<string, unknown> {
+  if (!block) return {};
+  const lines = block.split("\n");
 
-/** Parse `key: value` lines from a frontmatter block's interior. */
-function parseFields(block: string): Record<string, string> {
-  const fields: Record<string, string> = {};
-  for (const line of block.split("\n")) {
-    const m = line.match(/^\s*([\w-]+):\s*(.*?)\s*$/);
-    if (m) fields[m[1]] = m[2];
+  // Find indent of first non-blank line. If all-blank, return empty mapping.
+  let indent = -1;
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    indent = line.match(/^(\s*)/)![1].length;
+    break;
   }
-  return fields;
+  if (indent === -1) return {};
+
+  // Dedent: strip `indent` leading characters from each non-blank line.
+  // Throw if any non-blank line has less leading whitespace than the first.
+  const dedented = lines.map((line) => {
+    if (line.trim() === "") return "";
+    const leading = line.match(/^(\s*)/)![1].length;
+    if (leading < indent) {
+      throw new Error(
+        `frontmatter: line "${line}" has ${leading} leading spaces; first non-blank line had ${indent}`,
+      );
+    }
+    return line.slice(indent);
+  });
+
+  const parsed = parseYAML(dedented.join("\n"));
+  if (parsed === null || parsed === undefined) return {};
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `frontmatter: YAML content is not a mapping (got ${Array.isArray(parsed) ? "array" : typeof parsed})`,
+    );
+  }
+  return parsed as Record<string, unknown>;
 }


### PR DESCRIPTION
Closes #209

## Summary

Adds `.github/scripts/vsdd/frontmatter.ts` — a generic parser for HTML-comment metadata blocks in VSDD comment bodies. Replaces the per-context regex implementations scattered across `phase-1c-budget.js`, `phase-1c-cardinality.js`, `vsdd-brand.js`, the interim parser in PR #194, and the planned #182 budget parser.

## Design

**The HTML comment IS the marker.** Two valid shapes only — inline (everything on one line) or block (wrappers each alone on their lines). Mixed shapes (`<!-- token\nbody\n-->`, `<!--\nbody-->`) silently fail to match.

```text
<!-- ...content on one line... -->         (inline)

<!--                                        (block)
...content lines...
-->
```

Content is parsed as YAML. Inline accepts any one-line YAML (scalar, flow-array, flow-mapping); block accepts multiline YAML (typically a mapping). Block form auto-dedents based on the first non-blank line's indent — throws if any later non-blank line is shorter.

```ts
import * as frontmatter from "../vsdd/frontmatter.ts";

frontmatter.parse(body)  // every well-formed block → unknown[] in source order
```

Convention-free API — discrimination between blocks (which is "mine"?) is the caller's job. Three patterns the repo's existing emitters can adopt:

1. **Inline scalar marker:** `<!-- vsdd-opt-out-brand -->` → `"vsdd-opt-out-brand"`
2. **kv-discrimination:** `<!-- vsdd-phase-3: { state: clear } -->` → `{ "vsdd-phase-3": { state: "clear" } }`
3. **Named-field:** `<!-- {kind: verdict, phase: 3, ...} -->` → `{ kind: "verdict", phase: 3, ... }`

## What's intentionally NOT in this PR

- **No call-site migrations.** The five existing parsers stay; each migration is its own atomic-PR per §VII (#204 sweep style). Each migration also restructures the emitted comment shape — the marker-header convention (`<!-- vsdd-phase-3\nbody\n-->`) is no longer parseable by this utility, by design.
- **No tests.** Per the no-tests-in-CI policy. Smoke verification in this PR description.

## Verification

`deno check` passes. Smoke tests covered:

**Inline form:**
- Scalar marker (`<!-- vsdd-opt-out-brand -->` → string)
- Flow-array (`<!-- [a, b, c] -->`)
- Flow-mapping (`<!-- {a: 1, b: 2} -->`)
- kv-discriminated (`<!-- vsdd-phase-3: {state: clear} -->`)
- Whitespace-only (skipped silently)
- Empty `<!---->` (no match)

**Block form:**
- Flat mapping
- Indented (auto-dedent)
- kv-discriminated multiline
- Trailing whitespace tolerated on wrapper lines
- Whitespace-only middle lines exempt from indent check

**Malformed shapes (silently rejected):**
- `<!-- token\nbody\n-->` (header on `<!--` line + body below)
- `<!--\nbody-->` (`-->` not alone on its line)
- `<!-- foo\n-->` (content on `<!--` line, no closer)
- `<!--\n\n-->` (empty body)
- `<!--\n-->` (single newline only)

**Other:**
- Multi-block in source order (multiple comments per body)
- Indent-violation throws explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)